### PR TITLE
Streamline processes and handle local files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -737,11 +737,6 @@ workflow {
         kneaddata.out.fastq,
         install_metaphlan_db.out.metaphlan_db.collect())
 
-    // metaphlan_unknown_list(
-    //     metaphlan_bugs_viruses_lists.out.meta,
-    //     metaphlan_bugs_viruses_lists.out.metaphlan_bt2,
-    //     install_metaphlan_db.out.metaphlan_db.collect())
-
     metaphlan_markers(
         metaphlan_unknown_viruses_lists.out.meta,
         metaphlan_unknown_viruses_lists.out.metaphlan_bt2,

--- a/main.nf
+++ b/main.nf
@@ -58,11 +58,8 @@ process fasterq_dump {
     echo "combining fastq files and gzipping"
     cat *.fastq | pv | pigz -p ${task.cpus} > out.fastq.gz
 
-    echo "sampling fastq file for fastqc"
-    seqtk sample -s100 out.fastq.gz 50000 > out_sample.fastq
-
     echo "running fastqc"
-    fastqc --extract out_sample.fastq
+    fastqc --extract out.fastq.gz
 
 
     echo "collecting version info"
@@ -128,11 +125,8 @@ process local_fastqc {
     echo "combining fastq files and gzipping"
     cat *.fastq | pv | pigz -p ${task.cpus} > out.fastq.gz
 
-    echo "sampling fastq file for fastqc"
-    seqtk sample -s100 out.fastq.gz 50000 > out_sample.fastq
-
     echo "running fastqc"
-    fastqc --extract out_sample.fastq
+    fastqc --extract out.fastq.gz
 
 
     echo "collecting version info"
@@ -177,7 +171,6 @@ process kneaddata {
     """
     kneaddata --unpaired ${fastq} \
         --reference-db ${params.organism_database} \
-        --reference-db ribosomal_RNA \
         --output kneaddata_output  \
         --trimmomatic /installed/Trimmomatic-0.39 \
         --bypass-trf \

--- a/main.nf
+++ b/main.nf
@@ -668,10 +668,10 @@ workflow {
         metaphlan_bugs_viruses_lists.out.metaphlan_sam,
         install_metaphlan_db.out.metaphlan_db.collect())
 
-    humann(
-       kneaddata.out.meta,
-       kneaddata.out.fastq,
-       metaphlan_bugs_viruses_lists.out.metaphlan_bugs_list,
-       chocophlan_db.out.chocophlan_db,
-       uniref_db.out.uniref_db)
+    // humann(
+    //    kneaddata.out.meta,
+    //    kneaddata.out.fastq,
+    //    metaphlan_bugs_viruses_lists.out.metaphlan_bugs_list,
+    //    chocophlan_db.out.chocophlan_db,
+    //    uniref_db.out.uniref_db)
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,7 +9,7 @@ params {
     cmgd_version = '4'
 
     // google
-    publish_dir = "gs://kaelyn-testing-cmgd/results/cMDv${params.cmgd_version}"
+    publish_dir = "gs://metagenomics-mac/results/cMDv${params.cmgd_version}"
 }
 
 manifest {
@@ -83,7 +83,7 @@ profiles {
     }
     unitn {
         process.executor = 'pbspro'
-        process.queue = 'short_cpuQ'
+        process.queue = 'CIBIO_cpuQ'
         process.server = 'hpc-head-n1.unitn.it'
         process.errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'ignore' }
         process.maxRetries = 3

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,18 +16,23 @@ params {
     uniref = 'uniref90_diamond'
     
     // Process control parameters
-    skip_humann = true  // Set to false to run HUMAnN processing
+    skip_humann = false  // Set to true to skip HUMAnN processing
     local_input = false  // Set to true to provide file paths rather than SRA accessions
     publish_mode = "copy" // Use to globally set publishDir mode
+
+    // biobakery databases
+    uniref                      = "uniref90_diamond"
+    chocophlan                  = "full"
+    metaphlan_index             = "latest"
 
     // CMGD version
     cmgd_version = '4'
 
     // google
-    // publish_dir = "gs://cmgd-data/results/cMDv${params.cmgd_version}"
+    publish_dir = "gs://cmgd-data/results/cMDv${params.cmgd_version}"
 
     // local output
-    publish_dir = "/shares/CIBIO-Storage/CM/scratch/users/kaelyn.long/cmd_nf/local_out"
+    // publish_dir = "/shares/CIBIO-Storage/CM/scratch/users/kaelyn.long/cmd_nf/local_out"
 }
 
 manifest {
@@ -37,7 +42,7 @@ manifest {
     homePage = 'https://github.com/seandavi/curatedmetagenomicsnextflow'
     mainScript = 'main.nf'
     name = 'cmgd_nextflow'
-    version = '1.2.0'
+    version = '1.3.0'
 
     // nextflowVersion
     // doi
@@ -67,9 +72,7 @@ weblog {
 }
 
 singularity.enabled = true
-singularity.pullTimeout = '2h'
 trace.overwrite = true
-process.container = 'docker://seandavi/curatedmetagenomics:4.0.0'
 
 
 profiles {
@@ -81,17 +84,19 @@ profiles {
         workDir = 'work'
 	    params.store_dir = '/anvil/scratch/x-seandavi/keep/store/'
         // process.executor = 'slurm'
+        process.container = 'docker://seandavi/curatedmetagenomics:metaphlan4.1.0'
     }
     alpine {
         process.errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'ignore' }
         process.maxRetries = 3
         workDir = 'work'
-        params.store_dir = "/scratch/alpine/${USER}/curatedMetagenomicsNextflow/keep/store/"
-        singularity.runOptions = "--bind /scratch/alpine/${USER}/curatedMetagenomicsNextflow/keep/store/:/keep/store/"
+        params.store_dir = '/home/seandavi@xsede.org/scratch/curatedMetagenomicsNextflow/keep/store/'
         // process.executor = 'slurm'
+        process.container = 'docker://seandavi/curatedmetagenomics:metaphlan4.1.0'
     }
     google {
         process.executor = 'google-batch'
+        process.container = 'seandavi/curatedmetagenomics:metaphlan4.1.0'
         workDir = 'gs://cmgd-data/work'
         process.maxRetries = 3
         google.batch.bootDiskSize = '100.GB'
@@ -108,11 +113,16 @@ profiles {
             executor = 'pbspro'
             queue = 'CIBIO_cpuQ'
             server = 'hpc-head-n1.unitn.it'
-            // errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'ignore' }
             errorStrategy = { (task.attempt <= 3) ? 'retry' : 'ignore' }            
             maxRetries = 3
             container = '/shares/CIBIO-Storage/CM/scratch/users/kaelyn.long/cmd_nf/singularity/krlong68-curatedmetagenomics-samtools-1.21.sif'
             module = 'singularity-3.4.0'
+        }
+                
+        singularity {
+           enabled = true
+            autoMounts = true
+            runOptions = '-B /shares/CIBIO-Storage'
         }
         
         workDir = 'work'

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,7 +4,7 @@ params {
     sample_id = null
     run_ids = null
     store_dir = 'databases'
-
+    
     // KneadData parameters
     organism_database = 'human_genome' // Alternative: 'mouse_C57BL'
     
@@ -72,6 +72,7 @@ weblog {
 }
 
 singularity.enabled = true
+singularity.pullTimeout = '2h'
 trace.overwrite = true
 
 
@@ -84,19 +85,20 @@ profiles {
         workDir = 'work'
 	    params.store_dir = '/anvil/scratch/x-seandavi/keep/store/'
         // process.executor = 'slurm'
-        process.container = 'docker://seandavi/curatedmetagenomics:metaphlan4.1.0'
+        process.container = 'docker://seandavi/curatedmetagenomics:4.0.0'
     }
     alpine {
         process.errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'terminate' }
         process.maxRetries = 3
         workDir = 'work'
-        params.store_dir = '/home/seandavi@xsede.org/scratch/curatedMetagenomicsNextflow/keep/store/'
+        params.store_dir = "/scratch/alpine/${USER}/curatedMetagenomicsNextflow/keep/store/"
+        singularity.runOptions = "--bind /scratch/alpine/${USER}/curatedMetagenomicsNextflow/keep/store/:/keep/store/"
         // process.executor = 'slurm'
-        process.container = 'docker://seandavi/curatedmetagenomics:metaphlan4.1.0'
+        process.container = 'docker://seandavi/curatedmetagenomics:4.0.0'
     }
     google {
         process.executor = 'google-batch'
-        process.container = 'seandavi/curatedmetagenomics:metaphlan4.1.0'
+        process.container = 'docker://seandavi/curatedmetagenomics:4.0.0'
         workDir = 'gs://cmgd-data/work'
         process.maxRetries = 3
         google.batch.bootDiskSize = '100.GB'

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,12 +17,17 @@ params {
     
     // Process control parameters
     skip_humann = true  // Set to false to run HUMAnN processing
+    local_input = false  // Set to true to provide file paths rather than SRA accessions
+    publish_mode = "copy" // Use to globally set publishDir mode
 
     // CMGD version
     cmgd_version = '4'
 
     // google
-    publish_dir = "gs://cmgd-data/results/cMDv${params.cmgd_version}"
+    // publish_dir = "gs://cmgd-data/results/cMDv${params.cmgd_version}"
+
+    // local output
+    publish_dir = "/shares/CIBIO-Storage/CM/scratch/users/kaelyn.long/cmd_nf/local_out"
 }
 
 manifest {
@@ -95,15 +100,22 @@ profiles {
         google.project = 'omicidx-338300'
     }
     unitn {
-        process.executor = 'pbspro'
-        process.queue = 'CIBIO_cpuQ'
-        process.server = 'hpc-head-n1.unitn.it'
-        process.errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'ignore' }
-        process.maxRetries = 3
+        executor {
+            queueSize = 80
+        }
+
+        process {
+            executor = 'pbspro'
+            queue = 'CIBIO_cpuQ'
+            server = 'hpc-head-n1.unitn.it'
+            // errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'ignore' }
+            errorStrategy = { (task.attempt <= 3) ? 'retry' : 'ignore' }            
+            maxRetries = 3
+            container = '/shares/CIBIO-Storage/CM/scratch/users/kaelyn.long/cmd_nf/singularity/krlong68-curatedmetagenomics-samtools-1.21.sif'
+            module = 'singularity-3.4.0'
+        }
+        
         workDir = 'work'
         params.store_dir = '/shares/CIBIO-Storage/CM/scratch/users/kaelyn.long/cmd_nf/keep/'
-        // process.container = 'docker://krlong68/curatedmetagenomics:samtools-1.21'
-        process.container = '/shares/CIBIO-Storage/CM/scratch/users/kaelyn.long/cmd_nf/singularity/krlong68-curatedmetagenomics-samtools-1.21.sif'
-        process.module = 'singularity-3.4.0'
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,6 +4,9 @@ params {
     sample_id = null
     run_ids = null
     store_dir = 'databases'
+
+    // KneadData parameters
+    organism_database = 'human_genome' // Alternative: mouse_C57BL
     
     // MetaPhlAn parameters
     metaphlan_index = 'latest'

--- a/nextflow.config
+++ b/nextflow.config
@@ -120,7 +120,7 @@ profiles {
         }
                 
         singularity {
-           enabled = true
+            enabled = true
             autoMounts = true
             runOptions = '-B /shares/CIBIO-Storage'
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,7 +6,7 @@ params {
     store_dir = 'databases'
 
     // KneadData parameters
-    organism_database = 'human_genome' // Alternative: mouse_C57BL
+    organism_database = 'human_genome' // Alternative: 'mouse_C57BL'
     
     // MetaPhlAn parameters
     metaphlan_index = 'latest'

--- a/submit_unitn.sh
+++ b/submit_unitn.sh
@@ -4,13 +4,13 @@
 # Usage
 # qsub -N job_name -v metadata_tsv=/absolute/path/to/samples.tsv submit_unitn.sh
 
-# 2 node
-# 4 core
+# 1 node
+# 1 core
 # 24 GB
-#PBS -l select=2:ncpus=4:mem=24gb
+#PBS -l select=1:ncpus=1:mem=24gb
 
 # 8 hours maximum execution time
-#PBS -l walltime=10:00:00
+##PBS -l walltime=10:00:00
 
 # execution queue: common_cpuQ; CIBIO_cpuQ
 #PBS -q CIBIO_cpuQ
@@ -24,7 +24,7 @@
 #PBS -k oed
 
 # send email on job abort, begin, end
-#PBS -m abe
+##PBS -m abe
 
 # email address for notifications
 ##PBS -M <your_email_address>
@@ -50,4 +50,4 @@ module load singularity-3.4.0
 cd $UNITN_SCRATCH
 export NXF_MODE=google
 
-nextflow run ASAP-MAC/metagenomicsNextflowMAC --metadata_tsv=$metadata_tsv -profile unitn -with-weblog https://nf-telemetry-819875667022.us-central1.run.app/nextflow-telemetry/events
+nextflow run ASAP-MAC/metagenomicsNextflowMAC --metadata_tsv=$metadata_tsv -profile unitn

--- a/submit_unitn.sh
+++ b/submit_unitn.sh
@@ -9,16 +9,10 @@
 # 24 GB
 #PBS -l select=1:ncpus=1:mem=24gb
 
-# 8 hours maximum execution time
-##PBS -l walltime=10:00:00
-
 # execution queue: common_cpuQ; CIBIO_cpuQ
 #PBS -q CIBIO_cpuQ
 
 # name the job on the command line: $ qsub -N job_name submit_unitn.sh
-
-# merge stdout and stderr
-##PBS -j oe
 
 # write output and error as job is progressing
 #PBS -k oed
@@ -35,7 +29,7 @@ echo "working in $UNITN_SCRATCH"
 
 echo "metadata_tsv: $metadata_tsv"
 
-export GOOGLE_APPLICATION_CREDENTIALS=/home/kaelyn.long/google_cred/curatedmetagenomicdata-232f4a306d1d.json
+export GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/keyfile.json
 
 # for allowing singularity to access $HOME/.ncbi/user-settings.mkfg
 # still not sure why user-settings that is supposed to be in Docker container isn't accessible
@@ -50,4 +44,4 @@ module load singularity-3.4.0
 cd $UNITN_SCRATCH
 export NXF_MODE=google
 
-nextflow run ASAP-MAC/metagenomicsNextflowMAC --metadata_tsv=$metadata_tsv -profile unitn
+nextflow run ASAP-MAC/metagenomicsNextflowMAC --metadata_tsv=$metadata_tsv -profile unitn -with-weblog https://nf-telemetry-819875667022.us-central1.run.app/nextflow-telemetry/events


### PR DESCRIPTION
Main changes in this PR:

- **Remove classical MetaPhlAn “bugs_list” in favor of only outputting the “unknown_list”.** The “unknown_list” is the same as the “bugs_list” with the addition of unclassified estimation. Relative abundances can be easily converted between the two when starting with unclassified estimation.
    - Process `metaphlan_bugs_viruses_lists` converted to `metaphlan_unknown_viruses_lists`
    - Process `metaphlan_unknown_list` removed
 - **KneadData databases**
    - Add option for `mouse_C57BL` database instead of `human_genome`
    - Add `--organism_database` parameter
    - Remove `ribo_rna` database
    - Only run the database installation process if required
 - **Local input/output**
    - Add ability to use locally stored files as input by including column `file_paths` in lieu of `NCBI_accession` in the `metadata_tsv` input file
    - Add `--local_input` flag
    - Add `local_fastqc` process
    - Add `publish_mode` parameter that affects all outputting processes to accommodate local directories for `publish_dir`
 - **Remove `seqtk` sampling before running FastQC**

I know that some features such as local input/output were already added and then removed in the past, so let me know if there are any considerations I’m missing. I’m also open to leaving any or all of these changes in our MAC-specific fork.