### PR TITLE
feat: workflow.onComplete / onError hooks → telemetry server

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -171,6 +171,64 @@ process {
 }
 
 /*
+ * Run-lifecycle hooks (workflow.onComplete / onError)
+ *
+ * Posts the workflow's final state to the telemetry server's run-event
+ * endpoint so the server has a definitive last-word for every run, even
+ * when nextflow itself errors before any process emits a weblog event
+ * (config parse error, plugin pull failure, DSL2 syntax error, etc.).
+ *
+ * No-ops cleanly when params.run_name or params.api_url is unset, so
+ * ad-hoc local runs are unaffected. All telemetry POSTs are best-effort
+ * and never fail the run.
+ */
+import groovy.json.JsonOutput
+
+def post_run_event = { Map body ->
+    if (!params.run_name || !params.api_url) return
+    def url = "${params.api_url}/runs/${params.run_name}/event"
+    try {
+        // ProcessBuilder takes a list of args, so curl receives the JSON
+        // payload exactly as written without any shell quoting concerns.
+        def pb = new ProcessBuilder([
+            'curl', '-sf', '-X', 'POST',
+            '--max-time', '15',
+            '-F', "event=${JsonOutput.toJson(body)}",
+            url,
+        ])
+        pb.redirectErrorStream(true)
+        def proc = pb.start()
+        proc.waitFor()
+    } catch (Throwable t) {
+        // Telemetry must NEVER fail a run.
+        System.err.println "[telemetry] post_run_event swallowed: ${t.message}"
+    }
+}
+
+def utc_now = {
+    new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", TimeZone.getTimeZone('UTC'))
+}
+
+workflow.onComplete = {
+    post_run_event([
+        type:           'workflow_oncomplete',
+        utc_time:       utc_now(),
+        success:        workflow.success,
+        exit_status:    workflow.exitStatus,
+        duration_ms:    workflow.duration?.toMillis(),
+        error_message:  workflow.errorMessage,
+    ])
+}
+
+workflow.onError = {
+    post_run_event([
+        type:           'workflow_onerror',
+        utc_time:       utc_now(),
+        error_message:  workflow.errorMessage,
+    ])
+}
+
+/*
  * Common runtime defaults
  */
 singularity.enabled = true


### PR DESCRIPTION
Phase 2 of seandavi/nextflow_telemetry#62. See seandavi/nextflow_telemetry#66 for the design.

## Summary

Adds \`workflow.onComplete\` and \`workflow.onError\` hooks to \`nextflow.config\` that POST the workflow's final state to the telemetry server's run-event endpoint. Closes the gap where nextflow errors out before any process emits a weblog event — config parse errors, plugin pull failures, DSL2 syntax errors, etc.

## Why

Today the server only learns about a run via:
- weblog events (per-process; silent if nextflow dies during init)
- the new wrapper events (Phase 3 in seandavi/nextflow_telemetry#67; SLURM/process boundary)

Neither sees Nextflow's own view of \"the workflow finished.\" These hooks fill that gap.

Combined with Phase 1 (server) + Phase 3 (wrapper):

\`\`\`
wrapper_started ──> pre_nextflow ──> [weblog stream] ──> workflow_oncomplete ──> wrapper_exited
                                       (per-process)        (this PR)              (uploads .nextflow.log)
\`\`\`

## Defensive design

- **No-op when \`params.run_name\` or \`params.api_url\` is absent.** Ad-hoc local runs that don't pass \`--run_name\` are entirely unaffected.
- **Telemetry must never fail a run.** Both hooks wrap their work in try/catch; failures are logged to stderr and swallowed.
- **No shell quoting concerns.** ProcessBuilder takes an arg list rather than a shell command, so the JSON payload passes through to curl literally.

## Test plan

This is a pipeline-side change that requires cluster validation — I cannot test it locally without a real run.

- [ ] Run a successful pipeline on Anvil; verify a row in \`telemetry\` with \`event = 'run_workflow_oncomplete'\` and \`metadata_->>'success' = 'true'\`
- [ ] Force an error path (e.g. pass an invalid \`--organism_database\` value) and verify a row with \`event = 'run_workflow_onerror'\` and \`error_message\` populated
- [ ] Run a local-only pipeline with no \`--run_name\` and verify the hooks are silent (no errors, no log noise)
- [ ] Run with a known-bad \`api_url\` and verify the hooks log to stderr but the run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)