### PR TITLE
Add MetaPhlAn-to-GTDB profile conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,9 +37,13 @@ nextflow run main.nf -profile local --metadata_tsv samples.tsv
 |------|-----------|
 | `preprocessing.nf` | `fasterq_dump`, `local_fastqc` |
 | `profiling.nf` | `kneaddata`, `metaphlan_*`, `sample_to_markers` |
-| `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN DBs) |
+| `rarefaction.nf` | `rarefy_fastq` (seqtk downsampling) |
+| `gtdb.nf` | `metaphlan_to_gtdb` (SGB→GTDB profile conversion) |
+| `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB DBs) |
 | `humann.nf` | HUMAnN gene/pathway abundance (disabled by default) |
 | `finalize.nf` | `MARK_COMPLETE` sentinel |
+
+GTDB conversion uses the vendored `bin/sgb_to_gtdb_profile.py` (Nextflow stages `bin/` onto `PATH`), a self-contained adaptation of MetaPhlAn's official `sgb_to_gtdb_profile.py` parameterized to read the assignment table from `store_dir` rather than the container's bundled copy.
 
 ### Configuration layers
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ nextflow run main.nf --metadata_tsv samples.tsv --skip_humann --publish_base_dir
 | ---------------- | -------------------------------- | ------- |
 | `skip_humann`    | Skip HUMAnN functional profiling | `true` |
 | `skip_rarefied`  | Skip the rarefied profiling branch | `false` |
+| `skip_gtdb`      | Skip MetaPhlAn-to-GTDB profile conversion | `false` |
 
 `skip_humann=true` is the current supported default. The `skip_humann=false`
 path is kept in the pipeline for future use, but it is not expected to work
@@ -86,10 +87,12 @@ under the sample directory, distinguished by a branch subdirectory:
 <sample>/full_data/metaphlan_lists/
 <sample>/full_data/metaphlan_markers/
 <sample>/full_data/strainphlan_markers/
+<sample>/full_data/gtdb/
 <sample>/rarefied_data/rarefaction/
 <sample>/rarefied_data/metaphlan_lists/
 <sample>/rarefied_data/metaphlan_markers/
 <sample>/rarefied_data/strainphlan_markers/
+<sample>/rarefied_data/gtdb/
 ```
 
 Set `--skip_rarefied` to suppress the rarefied branch and restore the original
@@ -101,6 +104,26 @@ single-branch layout (without the `full_data/` subdirectory prefix).
 | ----------------- | ---------------------- | -------- |
 | `metaphlan_index` | MetaPhlAn index to use | `mpa_vJan25_CHOCOPhlAnSGB_202503` |
 | `organism_database` | KneadData reference database | `human_genome` |
+
+### GTDB Parameters
+
+| Parameter      | Description                                          | Default |
+| -------------- | ---------------------------------------------------- | ------- |
+| `skip_gtdb`    | Disable MetaPhlAn-to-GTDB profile conversion         | `false` |
+| `sgb2gtdb_url` | URL of the SGB-to-GTDB assignment table (must match `metaphlan_index`) | MetaPhlAn `mpa_vJan25_CHOCOPhlAnSGB_202503` table |
+
+When `skip_gtdb=false` (the default), each MetaPhlAn relative-abundance profile
+is translated into a [GTDB-taxonomy](https://gtdb.ecogenomic.org/) profile using
+MetaPhlAn's official SGB-to-GTDB assignment table. The table is downloaded once
+into `store_dir` (process `sgb_to_gtdb_db`) and reused across runs. Conversion
+is performed by the vendored `bin/sgb_to_gtdb_profile.py` helper, which
+substitutes 1:1 mappings directly, bins (sums) n:1 mappings into the shared GTDB
+taxon, and aggregates abundances up the GTDB lineage. Output is published as
+`gtdb_profile.tsv.gz` under a `gtdb/` subdirectory in each branch.
+
+`sgb2gtdb_url` must be kept in lockstep with `metaphlan_index`: if the MetaPhlAn
+index changes, point `sgb2gtdb_url` at the assignment table that ships with the
+new index.
 
 ### HUMAnN Parameters
 
@@ -151,12 +174,14 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── full_data/
 │   │   │   │   ├── metaphlan_lists/
 │   │   │   │   ├── metaphlan_markers/
-│   │   │   │   └── strainphlan_markers/
+│   │   │   │   ├── strainphlan_markers/
+│   │   │   │   └── gtdb/         (only when --skip_gtdb false)
 │   │   │   └── rarefied_data/
 │   │   │       ├── rarefaction/
 │   │   │       ├── metaphlan_lists/
 │   │   │       ├── metaphlan_markers/
-│   │   │       └── strainphlan_markers/
+│   │   │       ├── strainphlan_markers/
+│   │   │       └── gtdb/         (only when --skip_gtdb false)
 │   │   ├── sample2/
 │   │   │   └── ...
 ```
@@ -172,6 +197,7 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── metaphlan_lists/
 │   │   │   ├── metaphlan_markers/
 │   │   │   ├── strainphlan_markers/
+│   │   │   ├── gtdb/           (only when --skip_gtdb false)
 │   │   │   └── humann/         (only when --skip_humann false)
 │   │   ├── sample2/
 │   │   │   └── ...

--- a/bin/sgb_to_gtdb_profile.py
+++ b/bin/sgb_to_gtdb_profile.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Convert a MetaPhlAn 4 SGB profile into a GTDB-taxonomy profile.
+
+This is a self-contained adaptation of the official MetaPhlAn utility
+(metaphlan/utils/sgb_to_gtdb_profile.py, by Aitor Blanco-Miguez). Two
+deliberate changes were made so the pipeline can own the mapping file:
+
+  1. The SGB->GTDB assignment table is supplied via -m/--mapping instead of
+     being hard-coded relative to the installed MetaPhlAn package. This lets
+     the Nextflow pipeline download and cache the table in its storeDir and
+     pass that copy in explicitly (see modules/processes/databases.nf).
+  2. The util_fun info/error helpers are inlined so the script runs standalone
+     from the pipeline bin/ directory without importing the MetaPhlAn package.
+
+The conversion logic (get_gtdb_profile) is otherwise unchanged from upstream:
+  - 1:1 mappings are substituted directly,
+  - n:1 mappings are binned (summed) into the shared GTDB taxon,
+  - higher ranks are aggregated up the lineage from species.
+
+Upstream source:
+https://github.com/biobakery/MetaPhlAn/blob/master/metaphlan/utils/sgb_to_gtdb_profile.py
+"""
+
+import sys
+import time
+import argparse as ap
+
+
+def info(message):
+    sys.stdout.write('{}\n'.format(message))
+    sys.stdout.flush()
+
+
+def error(message, exit=False):
+    sys.stderr.write('[ERROR] {}\n'.format(message))
+    sys.stderr.flush()
+    if exit:
+        sys.exit(1)
+
+
+def read_params():
+    """Reads and parses the command line arguments of the script."""
+    p = ap.ArgumentParser(
+        description=__doc__, formatter_class=ap.ArgumentDefaultsHelpFormatter)
+    p.add_argument('-i', '--input', type=str, default=None,
+                   help="The input MetaPhlAn SGB profile")
+    p.add_argument('-o', '--output', type=str, default=None,
+                   help="The output GTDB profile")
+    p.add_argument('-m', '--mapping', type=str, default=None,
+                   help="The SGB-to-GTDB assignment table (TSV)")
+    return p.parse_args()
+
+
+def check_params(args):
+    """Checks the mandatory command line arguments of the script."""
+    if not args.input:
+        error('-i (or --input) must be specified', exit=True)
+    if not args.output:
+        error('-o (or --output) must be specified', exit=True)
+    if not args.mapping:
+        error('-m (or --mapping) must be specified', exit=True)
+
+
+def get_gtdb_profile(mpa_profile, gtdb_profile, mapping_file):
+    """Creates the GTDB profile from a MetaPhlAn one."""
+    tax_levels = ['d', 'p', 'c', 'o', 'f', 'g', 's']
+
+    def get_parent_taxon(taxon, level):
+        parts = taxon.split(';')
+        if len(parts) > 1:
+            return ';'.join(parts[:-1])
+        else:
+            return parts[0]
+
+    sgb2gtdb = dict()
+    with open(mapping_file, 'r') as read_file:
+        for line in read_file:
+            line = line.strip().split('\t')
+            sgb2gtdb[line[0]] = line[1]
+    with open(gtdb_profile, 'w') as wf:
+        with open(mpa_profile, 'r') as rf:
+            unclassified = 0
+            abundances = {x: dict() for x in tax_levels}
+            for line in rf:
+                if line.startswith('#mpa_'):
+                    wf.write(line)
+                    wf.write('#clade_name\trelative_abundance\n')
+                elif line.startswith('UNCLASSIFIED'):
+                    unclassified = float(line.strip().split('\t')[2])
+                    wf.write('UNCLASSIFIED\t{}\n'.format(unclassified))
+                elif 't__SGB' in line:
+                    line = line.strip().split('\t')
+                    abundance = float(line[2])
+                    sgb_id = line[0].split('|')[-1][3:]
+                    gtdb_tax = sgb2gtdb.get(sgb_id, None)
+                    if gtdb_tax is None:
+                        continue
+                    if gtdb_tax not in abundances['s']:
+                        abundances['s'][gtdb_tax] = 0
+                    abundances['s'][gtdb_tax] += abundance
+        tax_levels_rev = list(reversed(tax_levels))
+        for i, tax_level in enumerate(tax_levels_rev[:-1]):
+            for tax in abundances[tax_level]:
+                parent_tax = get_parent_taxon(tax, tax_level)
+                new_level = tax_levels_rev[i + 1]
+                if parent_tax not in abundances[new_level]:
+                    abundances[new_level][parent_tax] = 0
+                abundances[new_level][parent_tax] += abundances[tax_level][tax]
+        for tax_level in tax_levels:
+            for tax in abundances[tax_level]:
+                wf.write('{}\t{}\n'.format(tax, abundances[tax_level][tax]))
+
+
+def main():
+    t0 = time.time()
+    args = read_params()
+    info("Start execution")
+    check_params(args)
+    get_gtdb_profile(args.input, args.output, args.mapping)
+    exec_time = time.time() - t0
+    info("Finish execution ({} seconds)".format(round(exec_time, 2)))
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/base.config
+++ b/conf/base.config
@@ -96,6 +96,16 @@ process {
         memory = { 1.GB * task.attempt }
     }
 
+    withName: 'sgb_to_gtdb_db' {
+        cpus = 1
+        memory = { 1.GB * task.attempt }
+    }
+
+    withName: 'metaphlan_to_gtdb' {
+        cpus = 1
+        memory = { 2.GB * task.attempt }
+    }
+
     withName: 'kneaddata_human_database' {
         cpus = 1
         memory = { 4.GB * task.attempt }

--- a/main.nf
+++ b/main.nf
@@ -23,6 +23,7 @@ include {
     uniref_db
     kneaddata_human_database
     kneaddata_mouse_database
+    sgb_to_gtdb_db
 } from './modules/processes/databases'
 include {
     kneaddata
@@ -35,6 +36,10 @@ include {
     sample_to_markers as sample_to_markers_rarefied
 } from './modules/processes/profiling'
 include { rarefy_fastq } from './modules/processes/rarefaction'
+include {
+    metaphlan_to_gtdb as metaphlan_to_gtdb_full
+    metaphlan_to_gtdb as metaphlan_to_gtdb_rarefied
+} from './modules/processes/gtdb'
 include { humann } from './modules/processes/humann'
 include { MARK_COMPLETE } from './modules/processes/finalize'
 
@@ -71,7 +76,7 @@ workflow {
      * - Or provide both run_ids and sample_id for a single sample
      */
     if (params.metadata_tsv == null) {
-        if (params.run_ids == null) or (params.sample_id == null) {
+        if (params.run_ids == null || params.sample_id == null) {
             error "Either metadata_tsv or run_ids/sample_id must be provided"
         } else {
             samples = generate_sample_metadata_single_sample(
@@ -112,6 +117,9 @@ workflow {
     utility_mapping_db()
     kneaddata_human_database()
     kneaddata_mouse_database()
+    if (!params.skip_gtdb) {
+        sgb_to_gtdb_db()
+    }
 
     /*
      * Core preprocessing and profiling section
@@ -169,6 +177,16 @@ workflow {
         install_metaphlan_db.out.metaphlan_db.collect())
 
     /*
+     * GTDB-taxonomy conversion of the full-depth MetaPhlAn profile.
+     */
+    if (!params.skip_gtdb) {
+        metaphlan_to_gtdb_full(
+            metaphlan_unknown_viruses_lists_full.out.meta,
+            metaphlan_unknown_viruses_lists_full.out.metaphlan_unknown_list,
+            sgb_to_gtdb_db.out.sgb2gtdb_db.collect())
+    }
+
+    /*
      * Optional rarefied branch
      *
      * Downsample reads with seqtk then run the same profiling steps under the
@@ -196,6 +214,13 @@ workflow {
             metaphlan_unknown_viruses_lists_rarefied.out.meta,
             metaphlan_unknown_viruses_lists_rarefied.out.metaphlan_sam,
             install_metaphlan_db.out.metaphlan_db.collect())
+
+        if (!params.skip_gtdb) {
+            metaphlan_to_gtdb_rarefied(
+                metaphlan_unknown_viruses_lists_rarefied.out.meta,
+                metaphlan_unknown_viruses_lists_rarefied.out.metaphlan_unknown_list,
+                sgb_to_gtdb_db.out.sgb2gtdb_db.collect())
+        }
     }
 
     /*
@@ -219,11 +244,21 @@ workflow {
      * Rarefied branch (when enabled): also join metaphlan_markers_rarefied and
      * sample_to_markers_rarefied.
      * HUMAnN branch (when enabled): additionally gate on humann output.
+     * GTDB branch (when enabled): additionally gate on the full-branch GTDB
+     * conversion.
      */
     finished_ch = metaphlan_markers_full.out.meta
         .map { meta -> tuple(meta.sample, meta) }
         .join(sample_to_markers_full.out.meta.map { meta -> tuple(meta.sample, meta) })
         .map { sample_id, meta1, meta2 -> meta1 }
+
+    if (!params.skip_gtdb) {
+        // Gate completion on the full-branch GTDB conversion when enabled.
+        finished_ch = finished_ch
+            .map { meta -> tuple(meta.sample, meta) }
+            .join(metaphlan_to_gtdb_full.out.meta.map { meta -> tuple(meta.sample, meta) })
+            .map { sample_id, meta1, meta2 -> meta1 }
+    }
 
     if (!params.skip_rarefied) {
         finished_rarefied_ch = metaphlan_markers_rarefied.out.meta

--- a/modules/processes/databases.nf
+++ b/modules/processes/databases.nf
@@ -144,6 +144,36 @@ process uniref_db {
     """
 }
 
+process sgb_to_gtdb_db {
+    label 'db_setup'
+    label 'download_retry'
+
+    cpus 1
+    memory "1g"
+
+    storeDir "${params.store_dir}"
+
+    output:
+    path "sgb_to_gtdb", emit: sgb2gtdb_db, type: 'dir'
+    path ".command*"
+
+    stub:
+    """
+    mkdir -p sgb_to_gtdb
+    touch sgb_to_gtdb/${file(params.sgb2gtdb_url).name}
+    touch .command.run
+    """
+
+    script:
+    """
+    echo ${PWD}
+    mkdir -p sgb_to_gtdb
+    # Download with the Python stdlib so we do not depend on curl/wget being
+    # present in the container (the MetaPhlAn image always ships Python).
+    python -c "import urllib.request; urllib.request.urlretrieve('${params.sgb2gtdb_url}', 'sgb_to_gtdb/${file(params.sgb2gtdb_url).name}')"
+    """
+}
+
 process kneaddata_human_database {
     label 'db_setup'
     label 'download_retry'

--- a/modules/processes/gtdb.nf
+++ b/modules/processes/gtdb.nf
@@ -1,0 +1,68 @@
+/*
+ * GTDB taxonomy conversion
+ *
+ * MetaPhlAn 4 reports taxonomy using its own SGB-based clade names. This step
+ * translates a MetaPhlAn relative-abundance profile into a GTDB-taxonomy
+ * profile using the official SGB->GTDB assignment table (downloaded and cached
+ * by the sgb_to_gtdb_db process). The conversion itself is performed by the
+ * vendored bin/sgb_to_gtdb_profile.py helper, which:
+ *   - substitutes 1:1 SGB->GTDB mappings directly,
+ *   - bins (sums) n:1 mappings into the shared GTDB taxon,
+ *   - aggregates abundances up the GTDB lineage.
+ *
+ * Outputs are published under the same per-sample/branch directory layout used
+ * by the rest of the pipeline, in a `gtdb` subdirectory.
+ */
+
+process metaphlan_to_gtdb {
+    label 'profiling'
+
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/${meta.branch ? meta.branch + '/' : ''}gtdb", pattern: "{*tsv.gz,.command*}", mode: "${params.publish_mode}"
+
+    tag "${meta.sample}"
+
+    cpus 1
+    memory "2g"
+
+    input:
+    val meta
+    path metaphlan_profile
+    path sgb2gtdb_db
+
+    output:
+    val(meta), emit: meta
+    path 'gtdb_profile.tsv', emit: gtdb_profile
+    path 'gtdb_profile.tsv.gz', emit: gtdb_profile_gz
+    path ".command*"
+    path "versions.yml"
+
+    stub:
+    """
+    touch gtdb_profile.tsv
+    touch gtdb_profile.tsv.gz
+    touch .command.run
+    touch versions.yml
+    """
+
+    script:
+    """
+    mapping_file=\$(find ${sgb2gtdb_db} -name '*SGB2GTDB.tsv' | head -n 1)
+    if [ -z "\$mapping_file" ]; then
+        echo "ERROR: no SGB2GTDB mapping table found in ${sgb2gtdb_db}" >&2
+        exit 1
+    fi
+
+    sgb_to_gtdb_profile.py \
+        -i ${metaphlan_profile} \
+        -o gtdb_profile.tsv \
+        -m "\$mapping_file"
+
+    gzip -c gtdb_profile.tsv > gtdb_profile.tsv.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        metaphlan: \$( echo \$(metaphlan --version 2>&1 ) | awk '{print \$3}')
+        sgb2gtdb_mapping: \$(basename \$mapping_file)
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,21 @@ params {
     // metaphlan_index = 'mpa_vOct22_CHOCOPhlAnSGB_202403' // required by humann4
 
     /*
+     * GTDB taxonomy conversion
+     *
+     * When skip_gtdb is false (the default), each MetaPhlAn profile is also
+     * translated into a GTDB-taxonomy profile and published under a `gtdb`
+     * subdirectory alongside the MetaPhlAn outputs. The SGB->GTDB assignment
+     * table is downloaded once into store_dir and reused across runs.
+     *
+     * sgb2gtdb_url must match the active metaphlan_index. The default points at
+     * the table that accompanies mpa_vJan25_CHOCOPhlAnSGB_202503; update it in
+     * lockstep with metaphlan_index if that changes.
+     */
+    skip_gtdb = false
+    sgb2gtdb_url = 'https://raw.githubusercontent.com/biobakery/MetaPhlAn/master/metaphlan/utils/mpa_vJan25_CHOCOPhlAnSGB_202503_SGB2GTDB.tsv'
+
+    /*
      * HUMAnN parameters
      *
      * The HUMAnN branch is currently disabled by default because the active

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -69,6 +69,16 @@
             "type": "string",
             "default": "latest"
         },
+        "skip_gtdb": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip translation of MetaPhlAn SGB profiles into GTDB-taxonomy profiles."
+        },
+        "sgb2gtdb_url": {
+            "type": "string",
+            "default": "https://raw.githubusercontent.com/biobakery/MetaPhlAn/master/metaphlan/utils/mpa_vJan25_CHOCOPhlAnSGB_202503_SGB2GTDB.tsv",
+            "description": "URL of the SGB-to-GTDB assignment table; must match metaphlan_index."
+        },
         "metadata_tsv": {
             "type": "string",
             "description": "The path to a tab-delimited sample sheet. This file MUST have columns: `study_name`, `sample_id`, and `NCBI_accessions`. The `NCBI_accessions` column should have SRA run accessions separated by `;`."

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -24,6 +24,25 @@ nextflow_pipeline {
         }
     }
 
+    test("Single-sample stub run completes with GTDB conversion disabled") {
+
+        when {
+            params {
+                sample_id = "TEST_SAMPLE"
+                run_ids = "SRR000001"
+                skip_humann = true
+                skip_gtdb = true
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.failed == false
+            assert workflow.exitStatus == 0
+            assert workflow.errorReport == null || workflow.errorReport.isEmpty()
+        }
+    }
+
     test("Missing sample arguments fails fast with a clear error") {
 
         when {
@@ -34,7 +53,9 @@ nextflow_pipeline {
 
         then {
             assert workflow.failed
-            assert workflow.errorReport.contains("Either metadata_tsv or run_ids/sample_id must be provided")
+            // The input-contract guard is a workflow-level error(), so the
+            // message surfaces on stdout rather than in a process errorReport.
+            assert workflow.stdout.any { it.contains("Either metadata_tsv or run_ids/sample_id must be provided") }
         }
     }
 }


### PR DESCRIPTION
Closes #18.

Adds GTDB-taxonomy conversion of MetaPhlAn 4 SGB profiles, as discussed in the issue (per @fasnicar's pointer to MetaPhlAn's `sgb_to_gtdb_profile.py` and the published `*_SGB2GTDB.tsv` table).

## What this does

For every MetaPhlAn relative-abundance profile, the pipeline now also produces a GTDB-taxonomy profile (`gtdb_profile.tsv.gz`), published under a `gtdb/` subdirectory in the same per-sample/branch layout as the existing outputs:

```
<sample>/full_data/gtdb/gtdb_profile.tsv.gz
<sample>/rarefied_data/gtdb/gtdb_profile.tsv.gz
```

(or `<sample>/gtdb/` when `--skip_rarefied` is set).

## Pieces

1. **TSV database config + download + storeDir** — new `sgb_to_gtdb_db` process downloads the SGB→GTDB assignment table once into `store_dir` and reuses it across runs. URL is configurable via `sgb2gtdb_url` and defaults to the table that matches the active `metaphlan_index` (`mpa_vJan25_CHOCOPhlAnSGB_202503`). Download uses the Python stdlib so it does not depend on curl/wget in the container.
2. **Conversion process** — new `metaphlan_to_gtdb` (module `modules/processes/gtdb.nf`) runs `bin/sgb_to_gtdb_profile.py`, a self-contained vendored adaptation of MetaPhlAn's official script, parameterized on `-m/--mapping` so it consumes **our** downloaded table rather than the container's bundled copy. The conversion logic is unchanged from upstream: 1:1 mappings substituted directly, n:1 mappings binned (summed) into the shared GTDB taxon, and abundances aggregated up the GTDB lineage.
3. **Wiring** — runs for both the full and rarefied branches; gated by `skip_gtdb` (default **false** — it's a cheap, high-value calculation we normally want). `MARK_COMPLETE` waits on the full-branch conversion when enabled.

## Also included

- Fixes a pre-existing invalid-Groovy bug in the input-contract guard (`... == null) or (...` → `|| `) so the single-sample validation path actually parses; the corresponding nf-test assertion now reads the workflow-level `error()` from stdout.

## Testing

- `just test-nf` — all 5 tests pass (added a `skip_gtdb=true` stub case).
- `just test-stub` — full DAG runs end-to-end in stub mode; `sgb_to_gtdb_db`, `metaphlan_to_gtdb_full`, and `metaphlan_to_gtdb_rarefied` all execute and publish into the expected `gtdb/` directories.
- `just test-config-all` — config resolves for all profiles.
- The vendored script was unit-checked on a synthetic profile: n:1 SGBs bin correctly and lineage aggregation sums as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)