### PR TITLE
Per-sample manifest + Architecture Decision Records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,18 @@ nextflow run main.nf -profile local --metadata_tsv samples.tsv
 | `profiling.nf` | `kneaddata`, `metaphlan_*`, `sample_to_markers` |
 | `rarefaction.nf` | `rarefy_fastq` (seqtk downsampling) |
 | `gtdb.nf` | `metaphlan_to_gtdb` (SGB→GTDB profile conversion) |
+| `manifest.nf` | `sample_manifest` (per-sample provenance + read-accounting `manifest.json`) |
 | `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB DBs) |
 | `humann.nf` | HUMAnN gene/pathway abundance (disabled by default) |
 | `finalize.nf` | `MARK_COMPLETE` sentinel |
 
 GTDB conversion uses the vendored `bin/sgb_to_gtdb_profile.py` (Nextflow stages `bin/` onto `PATH`), a self-contained adaptation of MetaPhlAn's official `sgb_to_gtdb_profile.py` parameterized to read the assignment table from `store_dir` rather than the container's bundled copy.
+
+`sample_manifest` writes one `manifest.json` at each sample's published root via `bin/build_manifest.py` (pure Python, no extra container). It compiles provenance, raw-vs-decontaminated read accounting, rarefaction parameters, and the consolidated per-process `versions.yml`. `MARK_COMPLETE` is gated on it so a sample directory is never marked complete before its manifest exists.
+
+### Architecture Decision Records
+
+Significant, non-obvious decisions are recorded as ADRs in `docs/adr/` (index in `docs/adr/README.md`). Consult them before changing container strategy, the HUMAnN default, the output layout, the GTDB conversion, the manifest, or the planned Kraken2/resistome steps — and add a new ADR (do not edit accepted ones) when making a comparably significant decision.
 
 ### Configuration layers
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Results will be organized by sample in the `publish_dir` directory.
 ├── cmgd_nextflow/
 │   ├── 1.6.0/
 │   │   ├── sample1/
+│   │   │   ├── manifest.json     (provenance + read accounting)
+│   │   │   ├── MARK_COMPLETE
 │   │   │   ├── kneaddata/
 │   │   │   ├── full_data/
 │   │   │   │   ├── metaphlan_lists/
@@ -193,6 +195,8 @@ Results will be organized by sample in the `publish_dir` directory.
 ├── cmgd_nextflow/
 │   ├── 1.6.0/
 │   │   ├── sample1/
+│   │   │   ├── manifest.json   (provenance + read accounting)
+│   │   │   ├── MARK_COMPLETE
 │   │   │   ├── kneaddata/
 │   │   │   ├── metaphlan_lists/
 │   │   │   ├── metaphlan_markers/
@@ -202,6 +206,24 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   ├── sample2/
 │   │   │   └── ...
 ```
+
+### Per-sample manifest
+
+Every sample gets a single `manifest.json` at its published root that compiles:
+
+- **provenance** — pipeline/Nextflow versions, container image, command line,
+  run name, git commit, key parameters, and input accessions/paths;
+- **read accounting** — raw and host-decontaminated read counts, base counts,
+  read-length statistics (min/median/max/mean) and GC%, plus the surviving
+  read/base fractions;
+- **rarefaction** parameters (when the rarefied branch is active);
+- **software_versions** — the per-process `versions.yml` files consolidated
+  into one tool→version map.
+
+Read statistics are computed by `bin/build_manifest.py` (pure Python, single
+streaming pass, no extra container). `MARK_COMPLETE` is gated on the manifest,
+so a sample directory is never marked complete before `manifest.json` exists.
+See [`docs/adr/0005-per-sample-manifest.md`](docs/adr/0005-per-sample-manifest.md).
 
 The sample-level directory name is the normalized `meta.sample` value used for
 task tags. That comes from `--sample_id` in single-sample mode or the

--- a/bin/build_manifest.py
+++ b/bin/build_manifest.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+"""Build a per-sample manifest.json compiling provenance + read accounting.
+
+Reads are profiled with a single streaming pass (no external tools), so this
+runs inside the base image without adding a dependency. Tool versions are
+merged from the per-process versions.yml files staged alongside this script.
+
+See docs/adr/0005-per-sample-manifest.md for the rationale.
+"""
+
+import argparse
+import glob
+import gzip
+import json
+import re
+import sys
+
+VERSION_LINE = re.compile(r"^([A-Za-z0-9_.\-]+):\s*(.+)$")
+
+
+def _open(path):
+    """Open a FASTQ whether or not it is gzip-compressed."""
+    if path.endswith(".gz"):
+        return gzip.open(path, "rt")
+    return open(path, "rt")
+
+
+def fastq_stats(path):
+    """Single-pass read/base/length/GC statistics over a FASTQ file.
+
+    Returns zeros for an empty or missing file so stub runs and edge cases do
+    not break manifest generation.
+    """
+    reads = 0
+    bases = 0
+    gc = 0
+    min_len = None
+    max_len = None
+    # Length histogram keeps memory bounded (read lengths are small integers)
+    # while still allowing an exact median.
+    length_hist = {}
+
+    try:
+        with _open(path) as fh:
+            for i, line in enumerate(fh):
+                if i % 4 != 1:  # only sequence lines
+                    continue
+                seq = line.strip()
+                n = len(seq)
+                reads += 1
+                bases += n
+                gc += seq.count("G") + seq.count("C") + seq.count("g") + seq.count("c")
+                length_hist[n] = length_hist.get(n, 0) + 1
+                if min_len is None or n < min_len:
+                    min_len = n
+                if max_len is None or n > max_len:
+                    max_len = n
+    except FileNotFoundError:
+        pass
+
+    median_len = None
+    if reads:
+        target = reads // 2
+        cumulative = 0
+        for length in sorted(length_hist):
+            cumulative += length_hist[length]
+            if cumulative > target:
+                median_len = length
+                break
+
+    return {
+        "number_reads": reads,
+        "number_bases": bases,
+        "minimum_read_length": min_len if min_len is not None else 0,
+        "maximum_read_length": max_len if max_len is not None else 0,
+        "median_read_length": median_len if median_len is not None else 0,
+        "mean_read_length": round(bases / reads, 2) if reads else 0,
+        "gc_percent": round(100.0 * gc / bases, 2) if bases else 0,
+    }
+
+
+def merge_versions(pattern="versions_*.yml"):
+    """Merge per-process versions.yml files into a single tool->version map."""
+    versions = {}
+    for path in sorted(glob.glob(pattern)):
+        try:
+            with open(path) as fh:
+                for line in fh:
+                    stripped = line.strip()
+                    if not stripped or stripped == "versions:":
+                        continue
+                    match = VERSION_LINE.match(stripped)
+                    if match:
+                        versions[match.group(1)] = match.group(2).strip()
+        except OSError:
+            continue
+    return versions
+
+
+def none_if_blank(value):
+    return value if value else None
+
+
+def as_bool(value):
+    return str(value).lower() == "true"
+
+
+def read_accounting(raw, decontaminated):
+    """Raw vs. host-decontaminated stats plus derived survival fractions."""
+    block = {
+        "raw": raw,
+        "decontaminated": decontaminated,
+    }
+    if raw["number_reads"]:
+        block["reads_surviving_fraction"] = round(
+            decontaminated["number_reads"] / raw["number_reads"], 4
+        )
+    if raw["number_bases"]:
+        block["bases_surviving_fraction"] = round(
+            decontaminated["number_bases"] / raw["number_bases"], 4
+        )
+    return block
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--sample", required=True)
+    p.add_argument("--pipeline-name", default="")
+    p.add_argument("--pipeline-version", default="")
+    p.add_argument("--nextflow-version", default="")
+    p.add_argument("--container", default="")
+    p.add_argument("--command-line", default="")
+    p.add_argument("--run-name", default="")
+    p.add_argument("--session-id", default="")
+    p.add_argument("--git-commit", default="")
+    p.add_argument("--git-revision", default="")
+    p.add_argument("--start-time", default="")
+    p.add_argument("--input-mode", default="")
+    p.add_argument("--input-ids", default="", help="comma-separated accessions or paths")
+    p.add_argument("--metaphlan-index", default="")
+    p.add_argument("--store-dir", default="")
+    p.add_argument("--skip-rarefied", default="false")
+    p.add_argument("--rarefy-reads", type=int, default=0)
+    p.add_argument("--rarefy-seed", type=int, default=0)
+    p.add_argument("--skip-humann", default="true")
+    p.add_argument("--skip-gtdb", default="false")
+    p.add_argument("--raw-fastq", required=True)
+    p.add_argument("--kneaddata-fastq", required=True)
+    p.add_argument("--output", default="manifest.json")
+    args = p.parse_args()
+
+    raw = fastq_stats(args.raw_fastq)
+    decontaminated = fastq_stats(args.kneaddata_fastq)
+
+    manifest = {
+        "sample_id": args.sample,
+        "provenance": {
+            "pipeline_name": none_if_blank(args.pipeline_name),
+            "pipeline_version": none_if_blank(args.pipeline_version),
+            "nextflow_version": none_if_blank(args.nextflow_version),
+            "container": none_if_blank(args.container),
+            "command_line": none_if_blank(args.command_line),
+            "run_name": none_if_blank(args.run_name),
+            "session_id": none_if_blank(args.session_id),
+            "git_commit": none_if_blank(args.git_commit),
+            "git_revision": none_if_blank(args.git_revision),
+            "start_time": none_if_blank(args.start_time),
+            "input_mode": none_if_blank(args.input_mode),
+            "input_ids": [x for x in args.input_ids.split(",") if x],
+        },
+        "parameters": {
+            "metaphlan_index": none_if_blank(args.metaphlan_index),
+            "store_dir": none_if_blank(args.store_dir),
+            "skip_humann": as_bool(args.skip_humann),
+            "skip_gtdb": as_bool(args.skip_gtdb),
+            "skip_rarefied": as_bool(args.skip_rarefied),
+        },
+        "read_accounting": read_accounting(raw, decontaminated),
+        "software_versions": merge_versions(),
+    }
+
+    if not as_bool(args.skip_rarefied):
+        manifest["parameters"]["rarefaction"] = {
+            "rarefy_reads": args.rarefy_reads,
+            "rarefy_seed": args.rarefy_seed,
+        }
+
+    with open(args.output, "w") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=False)
+        fh.write("\n")
+
+    sys.stderr.write("Wrote manifest for sample {}\n".format(args.sample))
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/base.config
+++ b/conf/base.config
@@ -121,6 +121,11 @@ process {
         memory = { 48.GB * task.attempt }
     }
 
+    withName: 'sample_manifest' {
+        cpus = 1
+        memory = { 2.GB * task.attempt }
+    }
+
     withName: 'MARK_COMPLETE' {
         cpus = 1
         memory = { 2.GB * task.attempt }

--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -1,0 +1,47 @@
+# 0000. Record architecture decisions
+
+- **Status:** Accepted
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+This pipeline has accumulated a number of significant, non-obvious decisions —
+why HUMAnN is disabled, why a single container image is used, why outputs are
+laid out the way they are. Until now these lived in GitHub issue threads, pull
+request discussions, and terse config comments. That makes them hard to find,
+easy to lose when an issue is closed, and impossible to grep. New contributors
+(human or agent) repeatedly re-derive or, worse, unknowingly contradict earlier
+reasoning.
+
+## Decision
+
+We will record architecturally significant decisions as **Architecture Decision
+Records (ADRs)** stored in `docs/adr/`, using a lightweight Nygard-style format
+(context / decision / alternatives / consequences). The process and index live
+in `docs/adr/README.md`. ADRs are immutable once accepted; a changed decision is
+captured by a new ADR that supersedes the old one.
+
+## Alternatives considered
+
+- **Keep decisions in issues/PRs** — the status quo. Rejected: not discoverable,
+  not versioned with the code, and lost when issues are closed or repos move.
+- **A single `DECISIONS.md` log** — simpler, but grows into an unsearchable wall
+  of text and offers no stable per-decision anchor to link to.
+- **A heavier ADR tool (MADR + tooling)** — more structure than a small project
+  needs right now; the format can grow later if warranted.
+
+## Consequences
+
+- Each substantive decision gets a durable, linkable home that travels with the
+  code and shows up in `git blame`/`grep`.
+- Small added ceremony: contributors must spend a few minutes writing an ADR for
+  significant changes. This is intentional friction, scoped to decisions that
+  are hard to reverse or non-obvious.
+- The existing body of decisions is being seeded retroactively (ADRs 0001–0007),
+  including historical ones that still shape current work.
+
+## References
+
+- Michael Nygard, "Documenting Architecture Decisions" (2011).
+- `docs/adr/README.md` for the process and index.

--- a/docs/adr/0001-container-strategy.md
+++ b/docs/adr/0001-container-strategy.md
@@ -1,0 +1,55 @@
+# 0001. Single base image, per-process biocontainers for new tools
+
+- **Status:** Accepted
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+Historically the pipeline runs every process inside one container image,
+`seandavi/curatedmetagenomics:metaphlan4.2.2`, pinned in `conf/base.config` and
+built manually via `docker/cloudbuild.yaml`. This was simple and kept the
+toolchain (KneadData, MetaPhlAn, HUMAnN, bowtie2, …) versioned together.
+
+As we add tools that are unrelated to MetaPhlAn — GTDB conversion, a per-sample
+manifest, Kraken2/Bracken, and a resistome caller (RGI/CARD) — the single-image
+approach starts to hurt: each new tool forces a rebuild of the one image,
+couples unrelated version upgrades, and grows the image toward a monolith whose
+dependency graph is hard to keep consistent.
+
+## Decision
+
+Keep the single base image for the **existing** MetaPhlAn/KneadData/HUMAnN
+toolchain, but introduce **per-process containers** (pinned biocontainers) for
+**newly added, independent tools** via Nextflow's `withName` container override.
+Prefer pure-stdlib implementations where a new tool would otherwise be pulled in
+only for something trivial (e.g. the manifest's read statistics are computed in
+Python, which the base image already provides, rather than adding a `seqkit`
+container).
+
+## Alternatives considered
+
+- **Bake every new tool into the base image** — keeps "one container," but
+  produces a monolithic image, couples unrelated upgrades, and makes every
+  addition a full rebuild-and-repush of a large image.
+- **Move fully to per-process biocontainers immediately** — cleanest long-term
+  nf-core-style model, but a large, risky migration of the stable existing
+  toolchain for no immediate benefit.
+
+## Consequences
+
+- New tools get independently pinned, smaller images and decoupled version
+  management; the stable MetaPhlAn image stops being a bottleneck.
+- The pipeline now mixes container provenance models. Each process must be
+  explicit about its container, and the base image remains the default.
+- A future ADR may migrate the existing toolchain to per-process containers if
+  the mixed model proves awkward; this decision deliberately defers that.
+
+## References
+
+- `conf/base.config` (`process.container` default and `withName` overrides).
+- `docker/cloudbuild.yaml` (base image build).
+- ADRs [0004](0004-gtdb-conversion-vendored-mapping.md),
+  [0005](0005-per-sample-manifest.md),
+  [0006](0006-kraken2-bracken-complementary-profiler.md),
+  [0007](0007-resistome-rgi-card.md) all rely on this strategy.

--- a/docs/adr/0002-defer-humann.md
+++ b/docs/adr/0002-defer-humann.md
@@ -1,0 +1,54 @@
+# 0002. Defer HUMAnN functional profiling pending version alignment
+
+- **Status:** Accepted
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+The pipeline contains a complete HUMAnN functional-profiling branch (gene
+families, pathways, EC abundances) wired through `modules/processes/humann.nf`
+and the ChocoPhlAn/UniRef/utility-mapping database downloads. Functional
+potential is one of the most-requested data products for a curated metagenomic
+resource.
+
+However, the branch is disabled by default (`skip_humann = true`). The active
+MetaPhlAn index (`mpa_vJan25_CHOCOPhlAnSGB_202503`) is newer than the
+MetaPhlAn/HUMAnN version combination this HUMAnN path can consume. Running the
+branch as-is produces incompatible or incorrect results, so it is not safe to
+enable without coordinated version alignment and validation. Today this rationale
+lives only as a comment in `nextflow.config`.
+
+## Decision
+
+Keep the HUMAnN branch in the codebase but **disabled by default**
+(`skip_humann = true`). Treat it as preserved-but-dormant. Re-enabling requires
+deliberately realigning the MetaPhlAn index with a HUMAnN-compatible version
+combination (the older `mpa_vOct22_CHOCOPhlAnSGB_202403` index is noted in config
+as the HUMAnN4-compatible option) and validating outputs before flipping the
+default.
+
+## Alternatives considered
+
+- **Remove the HUMAnN branch** — sheds dead code, but discards working plumbing
+  for a high-value data product we intend to restore. Rejected.
+- **Enable it now** — produces wrong results given the version mismatch.
+  Rejected.
+- **Pin MetaPhlAn back to the HUMAnN-compatible index globally** — would
+  downgrade the taxonomic profiling everyone else depends on just to satisfy
+  HUMAnN. Rejected; the taxonomic index is the higher-priority contract.
+
+## Consequences
+
+- No functional profiles are published by default; downstream users get
+  taxonomy only until this is resolved.
+- The branch must be kept compiling and stub-testable so it does not rot while
+  dormant.
+- Re-enabling is a scoped, validated task (version alignment), not new
+  architecture — tracked as future work.
+
+## References
+
+- `nextflow.config` (`skip_humann`, `metaphlan_index`, and the
+  HUMAnN-compatible index comment).
+- `modules/processes/humann.nf`.

--- a/docs/adr/0003-dual-branch-rarefied-profiling.md
+++ b/docs/adr/0003-dual-branch-rarefied-profiling.md
@@ -1,0 +1,50 @@
+# 0003. Dual-branch profiling: full depth + rarefied
+
+- **Status:** Accepted
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+Sequencing depth is a dominant, study-specific confounder in metagenomic
+profiling: richness and the detectability of low-abundance taxa scale with read
+count, which complicates comparison across samples and studies sequenced at
+different depths. A curated resource that mixes many studies needs a way to
+support depth-controlled comparisons.
+
+## Decision
+
+By default (`skip_rarefied = false`) run profiling **twice**: once on the full
+host-decontaminated reads, and once on reads downsampled with `seqtk` to a fixed
+depth (`rarefy_reads`, default 1,000,000) using a fixed seed (`rarefy_seed`,
+default 42) for reproducibility. The two runs publish into branch-specific
+subdirectories (`full_data/` and `rarefied_data/`) so results can be compared
+side by side. Setting `skip_rarefied = true` restores the original single-branch
+layout with no `full_data/` prefix, preserving backward compatibility.
+
+## Alternatives considered
+
+- **Full depth only** — simplest, but pushes all depth normalization onto
+  downstream users, who then need the raw reads to redo it. Rejected for a
+  resource meant to be analysis-ready.
+- **Rarefied only** — discards information from deeply sequenced samples.
+  Rejected.
+- **Rarefy after profiling (subsample the profile)** — statistically inferior to
+  rarefying reads before alignment for marker-based profilers. Rejected.
+
+## Consequences
+
+- Roughly doubles the profiling compute per sample when enabled (two MetaPhlAn /
+  marker passes), accepted as the cost of depth-controlled comparability.
+- Output layout gains a branch dimension (`full_data/` vs `rarefied_data/`) that
+  every downstream profiling step (MetaPhlAn lists/markers, StrainPhlAn, GTDB)
+  must respect via `meta.branch`.
+- Per-sample **read accounting describes the real sample**, not the rarefied
+  copy; the rarefaction target/seed are recorded as parameters rather than as a
+  parallel accounting (see [0005](0005-per-sample-manifest.md)).
+
+## References
+
+- `modules/processes/rarefaction.nf`, `main.nf` (branch wiring), `nextflow.config`
+  (`skip_rarefied`, `rarefy_reads`, `rarefy_seed`).
+- Commit `82a6d68` (dual profiling branches with seqtk rarefaction).

--- a/docs/adr/0004-gtdb-conversion-vendored-mapping.md
+++ b/docs/adr/0004-gtdb-conversion-vendored-mapping.md
@@ -1,0 +1,61 @@
+# 0004. GTDB conversion via a vendored, store_dir-backed mapping table
+
+- **Status:** Accepted
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+MetaPhlAn 4 reports taxonomy using its own SGB clade names. Many downstream
+consumers want GTDB taxonomy. MetaPhlAn ships an official converter,
+`metaphlan/utils/sgb_to_gtdb_profile.py`, plus a versioned SGB→GTDB assignment
+table (`mpa_vJan25_CHOCOPhlAnSGB_202503_SGB2GTDB.tsv`). The mapping is not purely
+1:1 — some SGBs collapse n:1 onto a shared GTDB taxon, which the official script
+handles by binning and lineage aggregation.
+
+Two friction points with using the upstream script as-is:
+
+1. It hard-codes the assignment table path relative to the installed MetaPhlAn
+   package. We want the pipeline to own and pin that table (download once, cache,
+   reproduce), not depend on whatever copy happens to be baked into the container
+   image — which may be older than, or drift from, our pinned `metaphlan_index`.
+2. It imports MetaPhlAn package internals (`util_fun`), so it is awkward to run
+   standalone.
+
+## Decision
+
+**Vendor** a self-contained adaptation of the official script as
+`bin/sgb_to_gtdb_profile.py` (Nextflow stages `bin/` onto `PATH`), with two
+deliberate, minimal changes: (a) the assignment table is supplied via
+`-m/--mapping` instead of being hard-coded, and (b) the `info`/`error` helpers
+are inlined to drop the package import. The **conversion logic is unchanged**
+from upstream (1:1 substitution, n:1 binning, lineage aggregation). The table
+itself is downloaded once into `store_dir` by a dedicated `sgb_to_gtdb_db`
+process (URL is the `sgb2gtdb_url` parameter) and passed in explicitly.
+
+## Alternatives considered
+
+- **Call the script bundled in the container** — couples us to whatever version
+  the image ships and to its hard-coded table path; defeats pinning the mapping
+  to our `metaphlan_index`. Rejected.
+- **Reimplement the conversion from scratch** — risks diverging from the
+  validated upstream binning/aggregation behavior. Rejected in favor of a
+  faithful, minimally-patched copy.
+
+## Consequences
+
+- The SGB→GTDB table is a first-class, pinned, cached pipeline input; conversion
+  output is reproducible and decoupled from the container image's bundled copy.
+- We carry a vendored script that must be re-synced if upstream changes its
+  conversion logic. The file header records its upstream provenance to make that
+  sync deliberate.
+- `sgb2gtdb_url` must be kept in lockstep with `metaphlan_index`; this coupling
+  is documented in `nextflow.config` and the README.
+
+## References
+
+- PR #52 (implementation); closes issue #18.
+- `bin/sgb_to_gtdb_profile.py`, `modules/processes/gtdb.nf`,
+  `modules/processes/databases.nf` (`sgb_to_gtdb_db`).
+- Upstream: https://github.com/biobakery/MetaPhlAn/blob/master/metaphlan/utils/sgb_to_gtdb_profile.py
+- Relies on the container strategy in [0001](0001-container-strategy.md).

--- a/docs/adr/0005-per-sample-manifest.md
+++ b/docs/adr/0005-per-sample-manifest.md
@@ -1,0 +1,64 @@
+# 0005. Per-sample provenance & read-accounting manifest
+
+- **Status:** Accepted
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+The pipeline emits many per-step files (profiles, marker tables, logs) but
+nothing machine-readable that captures, per sample: how many reads/bases went
+in and survived QC, what was run, and with which versions. Downstream consumers
+need read depth and read-length statistics to filter samples and as covariates —
+depth is the dominant confounder in nearly every analysis. Today this
+information is scattered across the KneadData log and line-count files, and tool
+versions live in per-process `versions.yml` files that are never consolidated.
+
+## Decision
+
+Emit a single `manifest.json` at each sample's published root that compiles
+everything about the sample: provenance (pipeline/Nextflow version, container,
+command line, parameters, input accessions, timestamps), read accounting (raw
+and post-decontamination read counts, base counts, and read-length / GC
+statistics), the rarefaction parameters when that branch is active, and the
+consolidated tool versions.
+
+Specific choices:
+
+- **One file, sample root** — not per-branch. Read accounting describes the real
+  sample; the rarefied branch is a downsample and is represented by its
+  parameters, not a parallel accounting (see
+  [0003](0003-dual-branch-rarefied-profiling.md)).
+- **No strict schema alignment** to the consumer's column names. We emit clear,
+  stable field names; mapping to the curated resource's schema happens post-hoc.
+- **No in-pipeline checksums.** Production output lands in cloud object storage,
+  which records per-object MD5/CRC32C for free; computing our own would add
+  complexity for no benefit. (Trade-off: local/non-cloud runs get no checksums.)
+- **Read statistics computed in pure Python** over the FASTQs (single streaming
+  pass), so the manifest step needs no new tool/container — Python is already in
+  the base image (see [0001](0001-container-strategy.md)).
+
+## Alternatives considered
+
+- **MultiQC report** — great for human inspection, but produces HTML/aggregate
+  artifacts rather than a per-sample machine-readable record keyed to our output
+  layout. Complementary, not a substitute; may be added later.
+- **Add `seqkit`/`fastp` for stats** — faster, but pulls in another container
+  for something a short Python pass does adequately. Rejected per
+  [0001](0001-container-strategy.md).
+- **Match the consumer schema exactly in-pipeline** — brittle coupling to an
+  external schema that changes independently; the consumer maps post-hoc instead.
+
+## Consequences
+
+- Every sample gets a durable, greppable provenance + QC record that downstream
+  filtering and normalization can key on directly.
+- Per-process `versions.yml` files are consolidated into the manifest, giving
+  one place to read the full toolchain version set per run.
+- The manifest is a late/finalize-style step that depends on read inputs and the
+  collected version files; it does not gate the profiling branches.
+- Read-statistics cost is one extra streaming pass over each FASTQ per sample.
+
+## References
+
+- `modules/processes/manifest.nf`, `bin/build_manifest.py`, `main.nf` (wiring).

--- a/docs/adr/0006-kraken2-bracken-complementary-profiler.md
+++ b/docs/adr/0006-kraken2-bracken-complementary-profiler.md
@@ -1,0 +1,74 @@
+# 0006. Complementary read-based profiling with Kraken2 + Bracken
+
+- **Status:** Accepted (not yet implemented)
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+MetaPhlAn is marker-based: precise, but it only sees taxa represented in its
+marker database, and the unclassified ("unknown") fraction can be large. A
+k-mer-based profiler (Kraken2 + Bracken) classifies the whole read set, giving a
+read-count-based, methodologically independent view — useful for triangulation
+and for sample types where the marker view is incomplete.
+
+The cohort spans multiple body sites (gut, airway, skin, vaginal), so the
+reference database must be broad rather than gut-specific. The deployment target
+includes HPC where the database sits on a **shared filesystem** and **every
+process runs on a fresh node** (no opportunity to reuse a node-local staged
+copy). Read lengths skew short — many samples are historical (~100 bp).
+
+## Decision
+
+Add Kraken2 + Bracken as an **opt-out** complementary profiler
+(`skip_kraken`-style flag), running on the host-decontaminated reads on the same
+branches as MetaPhlAn (full and rarefied).
+
+- **Database:** PlusPF (RefSeq bacteria/archaea/viral + protozoa + **fungi** +
+  human decoy), **capped to 32 GB** by default, switchable to 64 GB via a
+  `kraken_db_url`-style parameter. PlusPF (not gut-specific UHGG) because the
+  cohort is multi-body-site; fungi matter for skin (*Malassezia*).
+- **Loading:** run `kraken2` in **default mode (load DB into RAM)**, reading the
+  DB directly from its staged `store_dir` location — *not* memory-mapping and
+  *not* staging to node-local scratch. We have the RAM, and this avoids
+  cluster-specific scratch-path logic; it is also the same idiom the existing DB
+  inputs use. Provision ~48 GB for the 32 GB DB.
+- **Throttle:** cap concurrency with `maxForks` on the Kraken process to prevent
+  a batch of fresh nodes from each reading the DB off the shared filesystem
+  simultaneously (a "thundering herd" on shared storage).
+- **Bracken:** use the prebuilt distribution matching the chosen DB at **100 bp**.
+
+## Alternatives considered
+
+- **UHGG / GTDB gut-specific DB** — highest gut completeness and taxonomy
+  coherent with our GTDB output, but prokaryote-only and gut-tuned; it would
+  misclassify airway/skin/vaginal samples and miss the mycobiome. Rejected
+  because the cohort is multi-site.
+- **Full / larger DB (PlusPF full, or 64 GB default)** — better rare-tail
+  sensitivity, but doubles per-task shared-FS read and RAM. The gain is in
+  low-abundance taxa we trust least (especially in low-biomass skin/airway
+  samples), and MetaPhlAn remains the authoritative profiler. Kept as a
+  parameter-flip option rather than the default.
+- **8 GB capped DB** — too lossy for an authoritative resource. Rejected.
+- **Stage-to-scratch + `--memory-mapping`** — decouples RAM from DB size, but
+  adds per-cluster scratch handling and a redundant copy for no benefit when RAM
+  is available. Rejected.
+
+## Consequences
+
+- Adds a read-count-based, whole-community profile complementing MetaPhlAn's
+  relative abundances; helps explain the MetaPhlAn unknown fraction.
+- In CPU-hours Kraken2+Bracken is comparable-to-cheaper than MetaPhlAn; the real
+  cost is a higher **memory tier** (~48 GB) and **shared-FS read I/O** paid per
+  task (no node reuse), mitigated by the cap and the `maxForks` throttle.
+- Kraken/Bracken report a different taxonomy than the GTDB output; cross-profiler
+  comparison must account for that.
+- New tool ⇒ per-process container per [0001](0001-container-strategy.md); DB
+  download follows the `store_dir` pattern.
+
+## References
+
+- ADR [0001](0001-container-strategy.md) (per-process container).
+- Bracken read-length rationale: predominantly ~100 bp historical reads.
+- To be implemented: `modules/processes/kraken.nf`, `databases.nf`
+  (`kraken_db`), `main.nf` wiring, `conf/base.config` resource tier + `maxForks`.

--- a/docs/adr/0007-resistome-rgi-card.md
+++ b/docs/adr/0007-resistome-rgi-card.md
@@ -1,0 +1,47 @@
+# 0007. Resistome profiling with RGI against CARD
+
+- **Status:** Accepted (not yet implemented)
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+Antimicrobial-resistance (AMR) gene content is one of the most-cited reuses of
+shotgun metagenomes, and the pipeline currently produces none. We want a
+per-sample resistome profile without requiring assembly, to keep it cheap and
+applicable to shallow/historical samples.
+
+## Decision
+
+Add a read-based resistome step using **RGI (Resistance Gene Identifier) against
+the CARD database**, emitting a per-sample AMR gene abundance table (gene plus
+AMR family / drug class), assembly-free. Like the other reference databases,
+CARD is downloaded/cached under `store_dir`, and RGI runs in its own pinned
+container per [0001](0001-container-strategy.md).
+
+## Alternatives considered
+
+- **AMR++ / MEGARes** — purpose-built for read-based resistome *quantification*
+  with a hierarchical ontology; a reasonable alternative. Chosen RGI/CARD instead
+  for CARD's curation and broad recognition in the gut/clinical literature, which
+  favors interpretability and comparability for a curated resource.
+- **Assembly + contig-based ARG calling (e.g. AMRFinderPlus)** — higher
+  precision and gives genomic context (co-localization, mobility), but requires
+  per-sample assembly, which is a separate, heavier scope decision we have not
+  taken. Rejected for the read-based first pass.
+
+## Consequences
+
+- Adds a widely-requested AMR data product at modest, assembly-free cost.
+- Read-based calls lack genomic context (no contig/mobility information); that is
+  accepted for this first pass and could be revisited if assembly is later added.
+- Virulence-factor profiling (e.g. VFDB) is a natural sibling and could reuse the
+  same read-based pattern, but is out of scope here.
+
+## References
+
+- CARD / RGI: https://card.mcmaster.ca/
+- ADR [0001](0001-container-strategy.md) (per-process container), `store_dir`
+  database pattern.
+- To be implemented: `modules/processes/resistome.nf`, `databases.nf` (CARD
+  download), `main.nf` wiring.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,57 @@
+# Architecture Decision Records
+
+This directory holds **Architecture Decision Records (ADRs)** — short documents
+that capture a single significant decision: the context that forced it, the
+choice we made, the alternatives we rejected, and the consequences we accept.
+
+We use ADRs because decisions were previously scattered across GitHub issues,
+PR threads, and config comments, where they are hard to find and easy to lose.
+An ADR is the durable, greppable home for *why* the pipeline is shaped the way
+it is.
+
+## When to write one
+
+Write an ADR when a decision:
+
+- is hard or expensive to reverse (e.g. output directory contract, container
+  strategy, taxonomy choice), or
+- has non-obvious rationale that a future maintainer would otherwise have to
+  reconstruct, or
+- was contested — there were real alternatives with real trade-offs.
+
+Do **not** write one for routine, easily-reversible changes (a bug fix, a
+dependency bump, a rename). Those belong in the commit message.
+
+## How to write one
+
+1. Copy [`template.md`](template.md) to `NNNN-short-title.md`, where `NNNN` is
+   the next zero-padded number in sequence.
+2. Fill it in. Keep it short — one decision, one page.
+3. Set the status (see below).
+4. Add a row to the index below.
+5. Commit it alongside the change it documents where possible.
+
+ADRs are immutable once `Accepted`. To change a decision, write a **new** ADR
+that supersedes the old one, and update both `Status` lines to point at each
+other. This preserves the historical record rather than rewriting it.
+
+## Status values
+
+- **Proposed** — under discussion, not yet acted on.
+- **Accepted** — the decision is in force.
+- **Accepted (not yet implemented)** — agreed, but the code does not exist yet.
+- **Superseded by [NNNN](NNNN-...md)** — replaced by a later decision.
+- **Deprecated** — no longer relevant, but kept for the record.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0000](0000-record-architecture-decisions.md) | Record architecture decisions | Accepted |
+| [0001](0001-container-strategy.md) | Single base image, per-process biocontainers for new tools | Accepted |
+| [0002](0002-defer-humann.md) | Defer HUMAnN functional profiling pending version alignment | Accepted |
+| [0003](0003-dual-branch-rarefied-profiling.md) | Dual-branch profiling: full depth + rarefied | Accepted |
+| [0004](0004-gtdb-conversion-vendored-mapping.md) | GTDB conversion via a vendored, store_dir-backed mapping table | Accepted |
+| [0005](0005-per-sample-manifest.md) | Per-sample provenance & read-accounting manifest | Accepted |
+| [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted (not yet implemented) |
+| [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted (not yet implemented) |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,29 @@
+# NNNN. Short title in the imperative
+
+- **Status:** Proposed | Accepted | Accepted (not yet implemented) | Superseded by [NNNN](NNNN-...md) | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** names
+
+## Context
+
+What is the situation that forces a decision? Capture the constraints, the
+forces in tension, and any relevant history. State facts, not the choice.
+
+## Decision
+
+The choice we are making, stated plainly. "We will …".
+
+## Alternatives considered
+
+- **Option A** — why we rejected it.
+- **Option B** — why we rejected it.
+
+## Consequences
+
+What becomes easier, harder, or constrained as a result. Include the costs we
+are knowingly accepting and any follow-up work this creates.
+
+## References
+
+Links to the issue, PR, commit, or external docs that motivated or implement
+this decision.

--- a/main.nf
+++ b/main.nf
@@ -41,6 +41,7 @@ include {
     metaphlan_to_gtdb as metaphlan_to_gtdb_rarefied
 } from './modules/processes/gtdb'
 include { humann } from './modules/processes/humann'
+include { sample_manifest } from './modules/processes/manifest'
 include { MARK_COMPLETE } from './modules/processes/finalize'
 
 /*
@@ -134,12 +135,18 @@ workflow {
      * versions (backward-compatible output layout).
      */
     if (params.local_input) {
+        raw_fastq_ch = local_fastqc.out.fastq
+        raw_versions_ch = local_fastqc.out.versions
+        raw_meta_ch = local_fastqc.out.meta
         kneaddata(
             local_fastqc.out.meta,
             local_fastqc.out.fastq,
             kneaddata_human_database.out.kd_genome.collect(),
             kneaddata_mouse_database.out.kd_mouse.collect())
     } else {
+        raw_fastq_ch = fasterq_dump.out.fastq
+        raw_versions_ch = fasterq_dump.out.versions
+        raw_meta_ch = fasterq_dump.out.meta
         kneaddata(
             fasterq_dump.out.meta,
             fasterq_dump.out.fastq,
@@ -185,6 +192,36 @@ workflow {
             metaphlan_unknown_viruses_lists_full.out.metaphlan_unknown_list,
             sgb_to_gtdb_db.out.sgb2gtdb_db.collect())
     }
+
+    /*
+     * Per-sample manifest
+     *
+     * Join (by sample) the raw reads + their versions, the host-decontaminated
+     * reads + versions, and the full-branch MetaPhlAn versions, then compile a
+     * single manifest.json per sample. Each output channel is merged from the
+     * same originating process so positions stay task-aligned before the join.
+     */
+    raw_for_manifest = raw_meta_ch
+        .merge(raw_fastq_ch)
+        .merge(raw_versions_ch)
+        .map { m, fq, ver -> tuple(m.sample, m, fq, ver) }
+
+    kneaddata_for_manifest = kneaddata.out.meta
+        .merge(kneaddata.out.fastq)
+        .merge(kneaddata.out.versions)
+        .map { m, fq, ver -> tuple(m.sample, fq, ver) }
+
+    metaphlan_versions_for_manifest = metaphlan_unknown_viruses_lists_full.out.meta
+        .merge(metaphlan_unknown_viruses_lists_full.out.versions)
+        .map { m, ver -> tuple(m.sample, ver) }
+
+    manifest_input = raw_for_manifest
+        .join(kneaddata_for_manifest)
+        .join(metaphlan_versions_for_manifest)
+        .map { sample, meta, raw_fq, raw_ver, kd_fq, kd_ver, mp_ver ->
+            tuple(meta, raw_fq, raw_ver, kd_fq, kd_ver, mp_ver) }
+
+    sample_manifest(manifest_input)
 
     /*
      * Optional rarefied branch
@@ -279,6 +316,13 @@ workflow {
             .join(humann.out.meta.map { meta -> tuple(meta.sample, meta) })
             .map { sample_id, meta1, meta2 -> meta1 }
     }
+
+    // Gate completion on the per-sample manifest so the published sample
+    // directory is not marked complete before manifest.json exists.
+    finished_ch = finished_ch
+        .map { meta -> tuple(meta.sample, meta) }
+        .join(sample_manifest.out.meta.map { meta -> tuple(meta.sample, meta) })
+        .map { sample_id, meta1, meta2 -> meta1 }
 
     MARK_COMPLETE(finished_ch)
 }

--- a/modules/processes/manifest.nf
+++ b/modules/processes/manifest.nf
@@ -1,0 +1,74 @@
+/*
+ * Per-sample manifest
+ *
+ * Compiles a single machine-readable manifest.json at the sample root with
+ * provenance (pipeline/Nextflow/container versions, command line, parameters,
+ * inputs), read accounting (raw vs. host-decontaminated read/base/length/GC
+ * statistics), the rarefaction parameters when that branch is active, and the
+ * consolidated per-process tool versions.
+ *
+ * Read statistics are computed in pure Python (bin/build_manifest.py) so this
+ * step needs no tool beyond the base image. See
+ * docs/adr/0005-per-sample-manifest.md.
+ */
+
+process sample_manifest {
+    label 'finalize'
+
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}", pattern: "manifest.json", mode: "${params.publish_mode}"
+
+    tag "${meta.sample}"
+
+    cpus 1
+    memory "2g"
+
+    input:
+    tuple val(meta),
+          path(raw_fastq),
+          path(raw_versions, stageAs: 'versions_raw.yml'),
+          path(kneaddata_fastq, stageAs: 'kneaddata.fastq'),
+          path(kneaddata_versions, stageAs: 'versions_kneaddata.yml'),
+          path(metaphlan_versions, stageAs: 'versions_metaphlan.yml')
+
+    output:
+    val(meta), emit: meta
+    path "manifest.json", emit: manifest
+    path ".command*"
+
+    stub:
+    """
+    echo '{"sample_id": "${meta.sample}", "stub": true}' > manifest.json
+    touch .command.run
+    """
+
+    script:
+    def cmd = workflow.commandLine ? workflow.commandLine.replaceAll('"', "'") : ''
+    def ids = meta.accessions ? meta.accessions.join(',') : (meta.fpaths ? meta.fpaths.join(',') : '')
+    def mode = params.local_input ? 'local' : 'sra'
+    """
+    build_manifest.py \
+        --sample '${meta.sample}' \
+        --pipeline-name '${workflow.manifest.name}' \
+        --pipeline-version '${workflow.manifest.version}' \
+        --nextflow-version '${workflow.nextflow.version}' \
+        --container '${task.container ?: ""}' \
+        --command-line "${cmd}" \
+        --run-name '${params.run_name ?: ""}' \
+        --session-id '${workflow.sessionId ?: ""}' \
+        --git-commit '${workflow.commitId ?: ""}' \
+        --git-revision '${workflow.revision ?: ""}' \
+        --start-time '${workflow.start ?: ""}' \
+        --input-mode '${mode}' \
+        --input-ids '${ids}' \
+        --metaphlan-index '${params.metaphlan_index}' \
+        --store-dir '${params.store_dir}' \
+        --skip-rarefied ${params.skip_rarefied} \
+        --rarefy-reads ${params.rarefy_reads} \
+        --rarefy-seed ${params.rarefy_seed} \
+        --skip-humann ${params.skip_humann} \
+        --skip-gtdb ${params.skip_gtdb} \
+        --raw-fastq ${raw_fastq} \
+        --kneaddata-fastq ${kneaddata_fastq} \
+        --output manifest.json
+    """
+}

--- a/modules/processes/preprocessing.nf
+++ b/modules/processes/preprocessing.nf
@@ -28,7 +28,7 @@ process fasterq_dump {
     path "fastq_line_count.txt"
     path ".command*"
     path "sampleinfo.txt"
-    path "versions.yml"
+    path "versions.yml", emit: versions
 
     stub:
     """
@@ -99,7 +99,7 @@ process local_fastqc {
     path "fastq_line_count.txt"
     path ".command*"
     path "sampleinfo.txt"
-    path "versions.yml"
+    path "versions.yml", emit: versions
 
     stub:
     """

--- a/modules/processes/profiling.nf
+++ b/modules/processes/profiling.nf
@@ -23,6 +23,7 @@ process kneaddata {
     path "kneaddata_output/out.fastq", emit: fastq
     path "kneaddata_output/kneaddata_fastq_linecounts.txt"
     path "kneaddata_output/out_kneaddata.log"
+    path "versions.yml", emit: versions
     path ".command*"
 
     stub:
@@ -31,6 +32,7 @@ process kneaddata {
     touch kneaddata_output/out.fastq
     touch kneaddata_output/kneaddata_fastq_linecounts.txt
     touch kneaddata_output/out_kneaddata.log
+    touch versions.yml
     """
 
     script:
@@ -48,6 +50,13 @@ process kneaddata {
     cat out_kneaddata.fastq | sed 's/^+.RR.*/+/g' > out.fastq
     rm out_kneaddata.fastq
     wc -l * | grep fastq > kneaddata_fastq_linecounts.txt
+    cd ..
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        kneaddata: \$( echo \$(kneaddata --version 2>&1 ) | awk '{print \$NF}')
+        trimmomatic: 0.39
+    END_VERSIONS
     """
 }
 
@@ -76,7 +85,7 @@ process metaphlan_unknown_viruses_lists {
     path 'metaphlan_viruses_list.tsv.gz', emit: metaphlan_viruses_list_gz
     path 'metaphlan.sam', emit: metaphlan_sam
     path ".command*"
-    path "versions.yml"
+    path "versions.yml", emit: versions
 
     stub:
     """


### PR DESCRIPTION
Two related additions: the first read-based enhancement we agreed on (the per-sample manifest), plus the ADR infrastructure to capture the decisions behind it and the rest of the roadmap.

## 1. Architecture Decision Records (`docs/adr/`)

We were burying decisions in issue threads and config comments. This sets up a lightweight Nygard-style ADR practice (`docs/adr/README.md` for process + index, `template.md`) and seeds the existing and in-flight decisions:

- **0000** record architecture decisions (meta)
- **0001** container strategy — single base image + per-process biocontainers for new tools
- **0002** HUMAnN deferred pending MetaPhlAn/HUMAnN version alignment *(historical, was only a config comment)*
- **0003** dual-branch full + rarefied profiling
- **0004** GTDB conversion via vendored, `store_dir`-backed mapping table (PR #52)
- **0005** per-sample manifest *(implemented here)*
- **0006** Kraken2 + Bracken complementary profiler *(decided, not yet built)*
- **0007** resistome via RGI/CARD *(decided, not yet built)*

ADRs 0006/0007 capture the design we settled on in discussion (PlusPF-capped-32 loaded into RAM, `maxForks` throttle, Bracken@100bp; RGI/CARD) so that context isn't lost before implementation.

## 2. Per-sample manifest (ADR-0005)

Every sample now gets one `manifest.json` at its published root compiling:

- **provenance** — pipeline/Nextflow/container versions, command line, run name, git commit, key parameters, input accessions/paths;
- **read accounting** — raw and host-decontaminated read counts, base counts, read-length min/median/max/mean, GC%, and surviving read/base fractions;
- **rarefaction** parameters (when that branch is active);
- **software_versions** — per-process `versions.yml` consolidated into one tool→version map.

Design choices (per our discussion): single file at the sample root (not per-branch — read accounting describes the real sample); no strict consumer-schema alignment (mapped post-hoc); no in-pipeline checksums (cloud storage provides MD5 for free); read stats computed in **pure Python** so no new container is needed.

`MARK_COMPLETE` is gated on the manifest, so a sample directory is never marked complete before `manifest.json` exists.

### Supporting changes
- Named the `versions.yml` emits on `fasterq_dump`/`local_fastqc`/`metaphlan_unknown_viruses_lists` and **added** a `versions.yml` to `kneaddata`, so the manifest can consolidate the toolchain versions.

## Testing
- `just test-nf` — all 5 tests pass. Because `MARK_COMPLETE` now depends on the manifest, the existing "completes through MARK_COMPLETE" test genuinely exercises the manifest path.
- `just test-stub` — full DAG runs; `manifest.json` is published at the sample root alongside `MARK_COMPLETE`/`full_data/`/`rarefied_data/`.
- `just test-config-all` — all profiles resolve.
- `build_manifest.py` verified on synthetic data: read/base/median-length/GC stats, raw-vs-decontaminated survival fractions, and versions.yml merge all correct.

Branched off `main` after the GTDB merge (#52), so ADR-0004 references real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)