### PR TITLE
Kraken2 + Bracken complementary read-based profiling (ADR-0006)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,14 +39,17 @@ nextflow run main.nf -profile local --metadata_tsv samples.tsv
 | `profiling.nf` | `kneaddata`, `metaphlan_*`, `sample_to_markers` |
 | `rarefaction.nf` | `rarefy_fastq` (seqtk downsampling) |
 | `gtdb.nf` | `metaphlan_to_gtdb` (SGB→GTDB profile conversion) |
+| `kraken.nf` | `kraken2`, `bracken` (complementary read-based profiling) |
 | `manifest.nf` | `sample_manifest` (per-sample provenance + read-accounting `manifest.json`) |
-| `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB DBs) |
+| `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB, Kraken2 DBs) |
 | `humann.nf` | HUMAnN gene/pathway abundance (disabled by default) |
 | `finalize.nf` | `MARK_COMPLETE` sentinel |
 
 GTDB conversion uses the vendored `bin/sgb_to_gtdb_profile.py` (Nextflow stages `bin/` onto `PATH`), a self-contained adaptation of MetaPhlAn's official `sgb_to_gtdb_profile.py` parameterized to read the assignment table from `store_dir` rather than the container's bundled copy.
 
 `sample_manifest` writes one `manifest.json` at each sample's published root via `bin/build_manifest.py` (pure Python, no extra container). It compiles provenance, raw-vs-decontaminated read accounting, rarefaction parameters, and the consolidated per-process `versions.yml`. `MARK_COMPLETE` is gated on it so a sample directory is never marked complete before its manifest exists.
+
+`kraken2`/`bracken` (module `kraken.nf`, gated by `skip_kraken`) add a complementary read-based profile under each branch's `kraken/` subdirectory. They use per-process StaPH-B containers and set all directives (container, resources, `maxForks`) **in the process body** rather than `conf/base.config`, because they are imported under aliases. The Kraken2 DB is loaded into RAM (default mode, not memory-mapped or staged to scratch) for cluster portability; `kraken_maxforks` throttles concurrent reads of the DB off shared storage. See ADR-0006.
 
 ### Architecture Decision Records
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ nextflow run main.nf --metadata_tsv samples.tsv --skip_humann --publish_base_dir
 | `skip_humann`    | Skip HUMAnN functional profiling | `true` |
 | `skip_rarefied`  | Skip the rarefied profiling branch | `false` |
 | `skip_gtdb`      | Skip MetaPhlAn-to-GTDB profile conversion | `false` |
+| `skip_kraken`    | Skip Kraken2 + Bracken read-based profiling | `false` |
 
 `skip_humann=true` is the current supported default. The `skip_humann=false`
 path is kept in the pipeline for future use, but it is not expected to work
@@ -88,11 +89,13 @@ under the sample directory, distinguished by a branch subdirectory:
 <sample>/full_data/metaphlan_markers/
 <sample>/full_data/strainphlan_markers/
 <sample>/full_data/gtdb/
+<sample>/full_data/kraken/
 <sample>/rarefied_data/rarefaction/
 <sample>/rarefied_data/metaphlan_lists/
 <sample>/rarefied_data/metaphlan_markers/
 <sample>/rarefied_data/strainphlan_markers/
 <sample>/rarefied_data/gtdb/
+<sample>/rarefied_data/kraken/
 ```
 
 Set `--skip_rarefied` to suppress the rarefied branch and restore the original
@@ -124,6 +127,34 @@ taxon, and aggregates abundances up the GTDB lineage. Output is published as
 `sgb2gtdb_url` must be kept in lockstep with `metaphlan_index`: if the MetaPhlAn
 index changes, point `sgb2gtdb_url` at the assignment table that ships with the
 new index.
+
+### Kraken2 / Bracken Parameters
+
+| Parameter             | Description                                                        | Default |
+| --------------------- | ------------------------------------------------------------------ | ------- |
+| `skip_kraken`         | Disable Kraken2 + Bracken read-based profiling                     | `false` |
+| `kraken_db_url`       | Prebuilt Kraken2 index tarball (bundles Bracken kmer distributions) | PlusPF 16 GB cap |
+| `kraken_confidence`   | Kraken2 `--confidence` threshold (0.0–1.0)                         | `0.0`   |
+| `kraken_maxforks`     | Max concurrent Kraken2 tasks (throttles shared-storage DB reads)   | `4`     |
+| `bracken_read_length` | Bracken read length (must have a matching kmer distribution)       | `100`   |
+
+When `skip_kraken=false` (the default), the host-decontaminated reads are
+classified with [Kraken2](https://ccb.jhu.edu/software/kraken2/) and re-estimated
+with [Bracken](https://ccb.jhu.edu/software/bracken/) at species and genus level,
+complementing MetaPhlAn's marker-based view with a whole-community, read-count
+profile. Outputs (`kraken2.report.txt.gz`, `bracken.species.txt.gz`,
+`bracken.genus.txt.gz`, and the Bracken-adjusted reports) are published under a
+`kraken/` subdirectory in each branch.
+
+The default database is the **16 GB capped PlusPF** index (RefSeq bacteria/
+archaea/viral + protozoa + fungi + human decoy) — broad enough for a multi-body-
+site cohort, including the skin/airway mycobiome. Prebuilt PlusPF indexes come
+in 8 GB, 16 GB, or full sizes (no 32 GB); point `kraken_db_url` at the full
+tarball for better rare-taxon sensitivity at higher RAM/I/O cost. The database is
+downloaded once into `store_dir` and **loaded into RAM** at run time (not
+memory-mapped or staged to node-local scratch) for cluster portability;
+`kraken_maxforks` limits how many tasks read it off shared storage at once. See
+[`docs/adr/0006-kraken2-bracken-complementary-profiler.md`](docs/adr/0006-kraken2-bracken-complementary-profiler.md).
 
 ### HUMAnN Parameters
 
@@ -177,13 +208,15 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   │   ├── metaphlan_lists/
 │   │   │   │   ├── metaphlan_markers/
 │   │   │   │   ├── strainphlan_markers/
-│   │   │   │   └── gtdb/         (only when --skip_gtdb false)
+│   │   │   │   ├── gtdb/         (only when --skip_gtdb false)
+│   │   │   │   └── kraken/       (only when --skip_kraken false)
 │   │   │   └── rarefied_data/
 │   │   │       ├── rarefaction/
 │   │   │       ├── metaphlan_lists/
 │   │   │       ├── metaphlan_markers/
 │   │   │       ├── strainphlan_markers/
-│   │   │       └── gtdb/         (only when --skip_gtdb false)
+│   │   │       ├── gtdb/         (only when --skip_gtdb false)
+│   │   │       └── kraken/       (only when --skip_kraken false)
 │   │   ├── sample2/
 │   │   │   └── ...
 ```
@@ -202,6 +235,7 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── metaphlan_markers/
 │   │   │   ├── strainphlan_markers/
 │   │   │   ├── gtdb/           (only when --skip_gtdb false)
+│   │   │   ├── kraken/         (only when --skip_kraken false)
 │   │   │   └── humann/         (only when --skip_humann false)
 │   │   ├── sample2/
 │   │   │   └── ...

--- a/docs/adr/0006-kraken2-bracken-complementary-profiler.md
+++ b/docs/adr/0006-kraken2-bracken-complementary-profiler.md
@@ -1,6 +1,6 @@
 # 0006. Complementary read-based profiling with Kraken2 + Bracken
 
-- **Status:** Accepted (not yet implemented)
+- **Status:** Accepted (implemented)
 - **Date:** 2026-06-03
 - **Deciders:** Sean Davis
 
@@ -66,9 +66,33 @@ branches as MetaPhlAn (full and rarefied).
 - New tool ⇒ per-process container per [0001](0001-container-strategy.md); DB
   download follows the `store_dir` pattern.
 
+## Update (implementation, 2026-06-03)
+
+Reconciling the decision with what is actually available and practical:
+
+- **DB cap is 16 GB, not 32 GB.** The prebuilt PlusPF indexes
+  (https://benlangmead.github.io/aws-indexes/k2) are offered only at 8 GB,
+  16 GB, or full — there is no 32 GB build, contrary to the original Decision.
+  The default `kraken_db_url` therefore points at the **16 GB** PlusPF cap
+  (release `20260226`); the parameter lets a user select the full (better
+  rare-tail sensitivity) or 8 GB build. The 16 GB cap is the closest available
+  match to the intent and loads comfortably into the provisioned RAM.
+- **Two processes, two StaPH-B containers.** Implemented as `kraken2`
+  (`staphb/kraken2:2.1.3`) feeding `bracken` (`staphb/bracken:2.9`) rather than
+  one combined container, because a single image confirmed to carry both tools
+  could not be verified. At abundance-estimation time Bracken needs only the DB
+  (which ships the kmer distributions) and the Kraken2 report, so it does not
+  need Kraken2 in its container.
+- **Directives in the process body, not `conf/base.config`.** Because the
+  processes are imported under aliases (`*_full`/`*_rarefied`), container, cpus,
+  memory (with `task.attempt` scaling), and `maxForks` are set in the process
+  bodies so they apply regardless of how selectors match aliases.
+- Memory tier is ~32 GB for the 16 GB DB (loaded into RAM); bump it if pointing
+  at the full DB.
+
 ## References
 
 - ADR [0001](0001-container-strategy.md) (per-process container).
 - Bracken read-length rationale: predominantly ~100 bp historical reads.
-- To be implemented: `modules/processes/kraken.nf`, `databases.nf`
-  (`kraken_db`), `main.nf` wiring, `conf/base.config` resource tier + `maxForks`.
+- Implemented in: `modules/processes/kraken.nf`, `modules/processes/databases.nf`
+  (`kraken_db`), `main.nf` wiring, `nextflow.config` parameters.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,5 +53,5 @@ other. This preserves the historical record rather than rewriting it.
 | [0003](0003-dual-branch-rarefied-profiling.md) | Dual-branch profiling: full depth + rarefied | Accepted |
 | [0004](0004-gtdb-conversion-vendored-mapping.md) | GTDB conversion via a vendored, store_dir-backed mapping table | Accepted |
 | [0005](0005-per-sample-manifest.md) | Per-sample provenance & read-accounting manifest | Accepted |
-| [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted (not yet implemented) |
+| [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted |
 | [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted (not yet implemented) |

--- a/main.nf
+++ b/main.nf
@@ -24,6 +24,7 @@ include {
     kneaddata_human_database
     kneaddata_mouse_database
     sgb_to_gtdb_db
+    kraken_db
 } from './modules/processes/databases'
 include {
     kneaddata
@@ -40,6 +41,12 @@ include {
     metaphlan_to_gtdb as metaphlan_to_gtdb_full
     metaphlan_to_gtdb as metaphlan_to_gtdb_rarefied
 } from './modules/processes/gtdb'
+include {
+    kraken2 as kraken2_full
+    kraken2 as kraken2_rarefied
+    bracken as bracken_full
+    bracken as bracken_rarefied
+} from './modules/processes/kraken'
 include { humann } from './modules/processes/humann'
 include { sample_manifest } from './modules/processes/manifest'
 include { MARK_COMPLETE } from './modules/processes/finalize'
@@ -121,6 +128,9 @@ workflow {
     if (!params.skip_gtdb) {
         sgb_to_gtdb_db()
     }
+    if (!params.skip_kraken) {
+        kraken_db()
+    }
 
     /*
      * Core preprocessing and profiling section
@@ -194,6 +204,22 @@ workflow {
     }
 
     /*
+     * Complementary read-based profiling (Kraken2 + Bracken) on the full-depth
+     * host-decontaminated reads.
+     */
+    if (!params.skip_kraken) {
+        kraken2_full(
+            full_meta_ch,
+            kneaddata.out.fastq,
+            kraken_db.out.kraken_db.collect())
+
+        bracken_full(
+            kraken2_full.out.meta,
+            kraken2_full.out.report,
+            kraken_db.out.kraken_db.collect())
+    }
+
+    /*
      * Per-sample manifest
      *
      * Join (by sample) the raw reads + their versions, the host-decontaminated
@@ -258,6 +284,18 @@ workflow {
                 metaphlan_unknown_viruses_lists_rarefied.out.metaphlan_unknown_list,
                 sgb_to_gtdb_db.out.sgb2gtdb_db.collect())
         }
+
+        if (!params.skip_kraken) {
+            kraken2_rarefied(
+                rarefy_fastq.out.meta,
+                rarefy_fastq.out.fastq,
+                kraken_db.out.kraken_db.collect())
+
+            bracken_rarefied(
+                kraken2_rarefied.out.meta,
+                kraken2_rarefied.out.report,
+                kraken_db.out.kraken_db.collect())
+        }
     }
 
     /*
@@ -294,6 +332,14 @@ workflow {
         finished_ch = finished_ch
             .map { meta -> tuple(meta.sample, meta) }
             .join(metaphlan_to_gtdb_full.out.meta.map { meta -> tuple(meta.sample, meta) })
+            .map { sample_id, meta1, meta2 -> meta1 }
+    }
+
+    if (!params.skip_kraken) {
+        // Gate completion on the full-branch Kraken2/Bracken profiling.
+        finished_ch = finished_ch
+            .map { meta -> tuple(meta.sample, meta) }
+            .join(bracken_full.out.meta.map { meta -> tuple(meta.sample, meta) })
             .map { sample_id, meta1, meta2 -> meta1 }
     }
 

--- a/modules/processes/databases.nf
+++ b/modules/processes/databases.nf
@@ -174,6 +174,42 @@ process sgb_to_gtdb_db {
     """
 }
 
+process kraken_db {
+    label 'db_setup'
+    label 'download_retry'
+
+    cpus 1
+    memory "4g"
+
+    storeDir "${params.store_dir}"
+
+    output:
+    path "kraken_db", emit: kraken_db, type: 'dir'
+    path ".command*"
+
+    stub:
+    """
+    mkdir -p kraken_db
+    touch kraken_db/hash.k2d
+    touch kraken_db/opts.k2d
+    touch kraken_db/taxo.k2d
+    touch kraken_db/database${params.bracken_read_length}mers.kmer_distrib
+    touch .command.run
+    """
+
+    script:
+    """
+    echo ${PWD}
+    mkdir -p kraken_db
+    # Prebuilt Kraken2 index tarballs bundle the Bracken kmer distributions and
+    # extract their .k2d files directly (no top-level directory), so unpack into
+    # kraken_db/. Stream the download to disk to avoid buffering a large file.
+    curl -fsSL "${params.kraken_db_url}" -o kraken_db.tar.gz
+    tar -xzf kraken_db.tar.gz -C kraken_db
+    rm -f kraken_db.tar.gz
+    """
+}
+
 process kneaddata_human_database {
     label 'db_setup'
     label 'download_retry'

--- a/modules/processes/kraken.nf
+++ b/modules/processes/kraken.nf
@@ -1,0 +1,125 @@
+/*
+ * Complementary read-based profiling: Kraken2 + Bracken (ADR-0006)
+ *
+ * Kraken2 classifies the host-decontaminated reads against a prebuilt PlusPF
+ * index; Bracken then re-estimates abundances at species and genus level. This
+ * complements MetaPhlAn's marker-based profiling with a whole-community,
+ * read-count-based view.
+ *
+ * Resource, container, and concurrency directives live in the process bodies
+ * (not conf/base.config) because these processes are imported under aliases for
+ * the full and rarefied branches; in-body directives apply regardless of alias.
+ *
+ * The database is loaded into RAM (default Kraken2 mode — no --memory-mapping
+ * and no staging to node-local scratch) for cluster portability. maxForks
+ * throttles how many tasks read the DB off shared storage at once.
+ */
+
+process kraken2 {
+    container 'docker://staphb/kraken2:2.1.3'
+
+    label 'profiling'
+
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/${meta.branch ? meta.branch + '/' : ''}kraken", pattern: "{*.report.txt.gz,.command*}", mode: "${params.publish_mode}"
+
+    tag "${meta.sample}"
+
+    cpus 8
+    memory { 32.GB * task.attempt }
+    maxForks params.kraken_maxforks
+
+    input:
+    val meta
+    path reads
+    path kraken_db
+
+    output:
+    val(meta), emit: meta
+    path "kraken2.report.txt", emit: report
+    path "kraken2.report.txt.gz", emit: report_gz
+    path ".command*"
+    path "versions.yml", emit: versions
+
+    stub:
+    """
+    touch kraken2.report.txt
+    touch kraken2.report.txt.gz
+    touch .command.run
+    touch versions.yml
+    """
+
+    script:
+    """
+    # Default mode loads the DB into RAM; the per-read output is discarded
+    # (Bracken consumes the report, not the per-read assignments).
+    kraken2 \
+        --db ${kraken_db} \
+        --threads ${task.cpus} \
+        --confidence ${params.kraken_confidence} \
+        --report kraken2.report.txt \
+        --output /dev/null \
+        ${reads}
+
+    gzip -c kraken2.report.txt > kraken2.report.txt.gz
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        kraken2: \$( kraken2 --version 2>&1 | head -1 | sed 's/Kraken version //' )
+    END_VERSIONS
+    """
+}
+
+process bracken {
+    container 'docker://staphb/bracken:2.9'
+
+    label 'profiling'
+
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/${meta.branch ? meta.branch + '/' : ''}kraken", pattern: "bracken*.txt.gz", mode: "${params.publish_mode}"
+
+    tag "${meta.sample}"
+
+    cpus 2
+    memory { 4.GB * task.attempt }
+
+    input:
+    val meta
+    path report
+    path kraken_db
+
+    output:
+    val(meta), emit: meta
+    path "bracken.species.txt.gz", emit: bracken_species
+    path "bracken.genus.txt.gz", emit: bracken_genus
+    path "bracken.species.report.txt.gz"
+    path "bracken.genus.report.txt.gz"
+    path ".command*"
+    path "versions.yml", emit: versions
+
+    stub:
+    """
+    touch bracken.species.txt.gz
+    touch bracken.genus.txt.gz
+    touch bracken.species.report.txt.gz
+    touch bracken.genus.report.txt.gz
+    touch .command.run
+    touch versions.yml
+    """
+
+    script:
+    """
+    bracken -d ${kraken_db} -i ${report} \
+        -o bracken.species.txt -w bracken.species.report.txt \
+        -r ${params.bracken_read_length} -l S
+    bracken -d ${kraken_db} -i ${report} \
+        -o bracken.genus.txt -w bracken.genus.report.txt \
+        -r ${params.bracken_read_length} -l G
+
+    gzip bracken.species.txt bracken.species.report.txt \
+         bracken.genus.txt bracken.genus.report.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        bracken: \$( echo \$(bracken -v 2>&1) | awk '{print \$NF}' )
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,6 +66,34 @@ params {
     sgb2gtdb_url = 'https://raw.githubusercontent.com/biobakery/MetaPhlAn/master/metaphlan/utils/mpa_vJan25_CHOCOPhlAnSGB_202503_SGB2GTDB.tsv'
 
     /*
+     * Kraken2 + Bracken complementary read-based profiling (ADR-0006)
+     *
+     * When skip_kraken is false (the default), the host-decontaminated reads are
+     * also classified with Kraken2 and re-estimated with Bracken, on the same
+     * branches as MetaPhlAn (full and rarefied). This gives a whole-community,
+     * read-count-based view that complements MetaPhlAn's marker-based relative
+     * abundances. Output is published under a `kraken` subdirectory.
+     *
+     * Database: kraken_db_url points at a prebuilt PlusPF index (RefSeq +
+     * protozoa + fungi + human decoy) from the Langmead/Wood index collection
+     * (https://benlangmead.github.io/aws-indexes/k2). Prebuilt caps are 8 GB,
+     * 16 GB, or full only — there is no 32 GB build — so the default is the
+     * 16 GB cap. Point this at the full or 8 GB tarball to trade I/O/RAM for
+     * sensitivity. The tarball bundles the Bracken kmer distributions.
+     *
+     * The DB is loaded into RAM (not memory-mapped, not staged to scratch) for
+     * cluster portability; kraken_maxforks throttles concurrent reads of the DB
+     * off shared storage. bracken_read_length must have a matching distribution
+     * in the DB (the PlusPF tarballs ship 50/75/100/150/200/250); 100 suits the
+     * predominantly short, historical reads in this cohort.
+     */
+    skip_kraken = false
+    kraken_db_url = 'https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_16_GB_20260226.tar.gz'
+    kraken_confidence = 0.0
+    kraken_maxforks = 4
+    bracken_read_length = 100
+
+    /*
      * HUMAnN parameters
      *
      * The HUMAnN branch is currently disabled by default because the active

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -79,6 +79,31 @@
             "default": "https://raw.githubusercontent.com/biobakery/MetaPhlAn/master/metaphlan/utils/mpa_vJan25_CHOCOPhlAnSGB_202503_SGB2GTDB.tsv",
             "description": "URL of the SGB-to-GTDB assignment table; must match metaphlan_index."
         },
+        "skip_kraken": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip complementary Kraken2 + Bracken read-based profiling."
+        },
+        "kraken_db_url": {
+            "type": "string",
+            "default": "https://genome-idx.s3.amazonaws.com/kraken/k2_pluspf_16_GB_20260226.tar.gz",
+            "description": "URL of a prebuilt Kraken2 index tarball (bundles Bracken kmer distributions). Prebuilt PlusPF caps are 8 GB, 16 GB, or full."
+        },
+        "kraken_confidence": {
+            "type": "number",
+            "default": 0.0,
+            "description": "Kraken2 --confidence threshold (0.0-1.0)."
+        },
+        "kraken_maxforks": {
+            "type": "integer",
+            "default": 4,
+            "description": "Max concurrent Kraken2 tasks; throttles reads of the DB off shared storage."
+        },
+        "bracken_read_length": {
+            "type": "integer",
+            "default": 100,
+            "description": "Bracken read length; must have a matching kmer distribution in the Kraken2 DB."
+        },
         "metadata_tsv": {
             "type": "string",
             "description": "The path to a tab-delimited sample sheet. This file MUST have columns: `study_name`, `sample_id`, and `NCBI_accessions`. The `NCBI_accessions` column should have SRA run accessions separated by `;`."

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -43,6 +43,25 @@ nextflow_pipeline {
         }
     }
 
+    test("Single-sample stub run completes with Kraken disabled") {
+
+        when {
+            params {
+                sample_id = "TEST_SAMPLE"
+                run_ids = "SRR000001"
+                skip_humann = true
+                skip_kraken = true
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.failed == false
+            assert workflow.exitStatus == 0
+            assert workflow.errorReport == null || workflow.errorReport.isEmpty()
+        }
+    }
+
     test("Missing sample arguments fails fast with a clear error") {
 
         when {


### PR DESCRIPTION
Implements **ADR-0006** — the second read-based enhancement from our roadmap. Adds a whole-community, read-count profile alongside MetaPhlAn's marker-based view.

## What it does

When `skip_kraken=false` (default), the host-decontaminated reads are classified with **Kraken2** and re-estimated with **Bracken** at species and genus level, on the same branches as MetaPhlAn (full + rarefied). Outputs land under a per-branch `kraken/` subdirectory:

```
<sample>/full_data/kraken/{kraken2.report.txt.gz, bracken.species.txt.gz, bracken.genus.txt.gz, *.report.txt.gz}
<sample>/rarefied_data/kraken/...
```

## Key implementation choices (per discussion + ADR-0006)

- **Database:** prebuilt **PlusPF** (RefSeq + protozoa + **fungi** + human decoy) — broad enough for the multi-body-site cohort (gut/airway/skin/vaginal), including the skin mycobiome. ⚠️ **Deviation from the ADR's "32 GB":** the Langmead prebuilt indexes only come in 8 GB / 16 GB / full — there is no 32 GB build — so the default is the **16 GB cap** (`k2_pluspf_16_GB_20260226`). `kraken_db_url` switches to full or 8 GB. I recorded this in an ADR-0006 implementation update.
- **DB loaded into RAM** (default Kraken2 mode — no `--memory-mapping`, no node-local scratch staging) for cluster portability, exactly as we discussed; `kraken_maxforks` (default 4) throttles concurrent reads of the DB off shared storage.
- **Bracken @ 100 bp** (matches the predominantly short, historical reads; the PlusPF tarball ships that distribution).
- **Two StaPH-B containers** (`staphb/kraken2:2.1.3` → `staphb/bracken:2.9`) rather than one combined image, since I couldn't verify a single image carrying both tools. Container/resources/`maxForks` are set **in the process bodies** because the processes are imported under aliases (`*_full`/`*_rarefied`), so `withName` selectors on aliases are unreliable.
- `MARK_COMPLETE` is gated on the full-branch Bracken.

## Testing
- `just test-nf` — 6/6 pass (added a `skip_kraken=true` stub case).
- `just test-stub` — full DAG runs; `kraken_db`, `kraken2_full/rarefied`, and `bracken_full/rarefied` all execute and publish into the expected `kraken/` dirs.
- `just test-config-all` — all profiles resolve.
- DB URL pulled live from the Langmead index page (not guessed); verify/bump the dated release as needed.

## Note for review
The StaPH-B container tags and the dated DB URL are the two things to sanity-check against current availability — both are single-line config/directive fixes if a tag/date has rolled. Stub tests don't pull containers, so a stale tag would only surface on a real run (clear pull error).

Branched off `main` after #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)