### PR TITLE
RGI/CARD read-based resistome profiling (ADR-0007)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,9 @@ nextflow run main.nf -profile local --metadata_tsv samples.tsv
 | `rarefaction.nf` | `rarefy_fastq` (seqtk downsampling) |
 | `gtdb.nf` | `metaphlan_to_gtdb` (SGB→GTDB profile conversion) |
 | `kraken.nf` | `kraken2`, `bracken` (complementary read-based profiling) |
+| `resistome.nf` | `resistome` (RGI/CARD read-based AMR profiling, full branch only) |
 | `manifest.nf` | `sample_manifest` (per-sample provenance + read-accounting `manifest.json`) |
-| `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB, Kraken2 DBs) |
+| `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB, Kraken2, CARD DBs) |
 | `humann.nf` | HUMAnN gene/pathway abundance (disabled by default) |
 | `finalize.nf` | `MARK_COMPLETE` sentinel |
 
@@ -50,6 +51,8 @@ GTDB conversion uses the vendored `bin/sgb_to_gtdb_profile.py` (Nextflow stages 
 `sample_manifest` writes one `manifest.json` at each sample's published root via `bin/build_manifest.py` (pure Python, no extra container). It compiles provenance, raw-vs-decontaminated read accounting, rarefaction parameters, and the consolidated per-process `versions.yml`. `MARK_COMPLETE` is gated on it so a sample directory is never marked complete before its manifest exists.
 
 `kraken2`/`bracken` (module `kraken.nf`, gated by `skip_kraken`) add a complementary read-based profile under each branch's `kraken/` subdirectory. They use per-process StaPH-B containers and set all directives (container, resources, `maxForks`) **in the process body** rather than `conf/base.config`, because they are imported under aliases. The Kraken2 DB is loaded into RAM (default mode, not memory-mapped or staged to scratch) for cluster portability; `kraken_maxforks` throttles concurrent reads of the DB off shared storage. See ADR-0006.
+
+`resistome` (module `resistome.nf`, gated by `skip_resistome`) runs RGI's read-based `bwt` workflow against CARD, publishing AMR gene/allele mapping tables under a `resistome/` subdirectory. It runs on the **full branch only** (ARGs are sparse at the rarefied depth) but keeps the branch-aware publishDir, so with rarefaction active it lands in `full_data/resistome/`. Container/resources are set in the process body. The RGI command sequence is not exercised by stub tests; validate it on a real sample. See ADR-0007.
 
 ### Architecture Decision Records
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ nextflow run main.nf --metadata_tsv samples.tsv --skip_humann --publish_base_dir
 | `skip_rarefied`  | Skip the rarefied profiling branch | `false` |
 | `skip_gtdb`      | Skip MetaPhlAn-to-GTDB profile conversion | `false` |
 | `skip_kraken`    | Skip Kraken2 + Bracken read-based profiling | `false` |
+| `skip_resistome` | Skip RGI/CARD resistome profiling (full branch only) | `false` |
 
 `skip_humann=true` is the current supported default. The `skip_humann=false`
 path is kept in the pipeline for future use, but it is not expected to work
@@ -156,6 +157,26 @@ memory-mapped or staged to node-local scratch) for cluster portability;
 `kraken_maxforks` limits how many tasks read it off shared storage at once. See
 [`docs/adr/0006-kraken2-bracken-complementary-profiler.md`](docs/adr/0006-kraken2-bracken-complementary-profiler.md).
 
+### Resistome (RGI/CARD) Parameters
+
+| Parameter        | Description                                          | Default |
+| ---------------- | ---------------------------------------------------- | ------- |
+| `skip_resistome` | Disable RGI/CARD resistome profiling                 | `false` |
+| `card_db_url`    | Canonical CARD data tarball URL                      | `https://card.mcmaster.ca/latest/data` |
+| `rgi_aligner`    | RGI `bwt` read aligner (`bowtie2`, `bwa`, or `kma`)  | `bowtie2` |
+
+When `skip_resistome=false` (the default), the host-decontaminated reads are
+profiled for antimicrobial-resistance genes with [RGI](https://github.com/arpcard/rgi)'s
+read-based `bwt` workflow against the [CARD](https://card.mcmaster.ca/) database,
+emitting per-sample gene- and allele-level mapping tables (`rgi_bwt.gene_mapping_data.txt.gz`,
+`rgi_bwt.allele_mapping_data.txt.gz`) plus mapping statistics under a `resistome/`
+subdirectory. CARD is downloaded once into `store_dir`.
+
+This step runs on the **full-depth branch only** — ARGs are rare and the rarefied
+1M-read depth yields a sparse, low-value resistome — so with the rarefied branch
+active it publishes under `full_data/resistome/`. See
+[`docs/adr/0007-resistome-rgi-card.md`](docs/adr/0007-resistome-rgi-card.md).
+
 ### HUMAnN Parameters
 
 | Parameter    | Description                 | Default            |
@@ -209,7 +230,8 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   │   ├── metaphlan_markers/
 │   │   │   │   ├── strainphlan_markers/
 │   │   │   │   ├── gtdb/         (only when --skip_gtdb false)
-│   │   │   │   └── kraken/       (only when --skip_kraken false)
+│   │   │   │   ├── kraken/       (only when --skip_kraken false)
+│   │   │   │   └── resistome/    (only when --skip_resistome false; full depth only)
 │   │   │   └── rarefied_data/
 │   │   │       ├── rarefaction/
 │   │   │       ├── metaphlan_lists/
@@ -236,6 +258,7 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── strainphlan_markers/
 │   │   │   ├── gtdb/           (only when --skip_gtdb false)
 │   │   │   ├── kraken/         (only when --skip_kraken false)
+│   │   │   ├── resistome/      (only when --skip_resistome false)
 │   │   │   └── humann/         (only when --skip_humann false)
 │   │   ├── sample2/
 │   │   │   └── ...

--- a/docs/adr/0007-resistome-rgi-card.md
+++ b/docs/adr/0007-resistome-rgi-card.md
@@ -1,6 +1,6 @@
 # 0007. Resistome profiling with RGI against CARD
 
-- **Status:** Accepted (not yet implemented)
+- **Status:** Accepted (implemented)
 - **Date:** 2026-06-03
 - **Deciders:** Sean Davis
 
@@ -38,10 +38,32 @@ container per [0001](0001-container-strategy.md).
 - Virulence-factor profiling (e.g. VFDB) is a natural sibling and could reuse the
   same read-based pattern, but is out of scope here.
 
+## Update (implementation, 2026-06-03)
+
+- **Full-depth branch only.** Unlike MetaPhlAn/GTDB/Kraken (which run on both
+  the full and rarefied branches), the resistome runs only on the full-depth
+  reads: ARGs are rare and the rarefied 1M-read depth yields a sparse,
+  low-value resistome. It still uses the conventional **branch-aware**
+  publishDir (`<sample>/<branch>/resistome`), so with the rarefied branch active
+  it publishes under `full_data/resistome/`.
+- **Opt-out (default on)** via `skip_resistome`, consistent with `skip_gtdb` /
+  `skip_kraken`.
+- **RGI `bwt` read-based workflow.** `rgi load --local` + `rgi card_annotation`
+  + `rgi bwt --read_one ... --local`. The reads are single-end (the pipeline is
+  unpaired throughout), so only `--read_one` is supplied. `rgi_aligner`
+  (default `bowtie2`) selects the bwt aligner. Container:
+  `quay.io/biocontainers/rgi:6.0.5` (set in the process body, alias-irrelevant
+  here but consistent with the Kraken processes).
+- **Caveat:** the RGI command sequence follows CARD documentation but is **not
+  exercised by stub tests** (which do not run containers) — the first real run
+  is the true validation, as with the Kraken DB/container specifics. The exact
+  biocontainer build suffix should be confirmed against current quay.io tags.
+
 ## References
 
 - CARD / RGI: https://card.mcmaster.ca/
 - ADR [0001](0001-container-strategy.md) (per-process container), `store_dir`
   database pattern.
-- To be implemented: `modules/processes/resistome.nf`, `databases.nf` (CARD
-  download), `main.nf` wiring.
+- Implemented in: `modules/processes/resistome.nf`,
+  `modules/processes/databases.nf` (`card_db`), `main.nf` wiring,
+  `nextflow.config` parameters.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,4 +54,4 @@ other. This preserves the historical record rather than rewriting it.
 | [0004](0004-gtdb-conversion-vendored-mapping.md) | GTDB conversion via a vendored, store_dir-backed mapping table | Accepted |
 | [0005](0005-per-sample-manifest.md) | Per-sample provenance & read-accounting manifest | Accepted |
 | [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted |
-| [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted (not yet implemented) |
+| [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted |

--- a/main.nf
+++ b/main.nf
@@ -25,6 +25,7 @@ include {
     kneaddata_mouse_database
     sgb_to_gtdb_db
     kraken_db
+    card_db
 } from './modules/processes/databases'
 include {
     kneaddata
@@ -47,6 +48,7 @@ include {
     bracken as bracken_full
     bracken as bracken_rarefied
 } from './modules/processes/kraken'
+include { resistome } from './modules/processes/resistome'
 include { humann } from './modules/processes/humann'
 include { sample_manifest } from './modules/processes/manifest'
 include { MARK_COMPLETE } from './modules/processes/finalize'
@@ -130,6 +132,9 @@ workflow {
     }
     if (!params.skip_kraken) {
         kraken_db()
+    }
+    if (!params.skip_resistome) {
+        card_db()
     }
 
     /*
@@ -217,6 +222,17 @@ workflow {
             kraken2_full.out.meta,
             kraken2_full.out.report,
             kraken_db.out.kraken_db.collect())
+    }
+
+    /*
+     * Resistome profiling (RGI/CARD) on the full-depth host-decontaminated
+     * reads. Full branch only — ARGs are too sparse at the rarefied depth.
+     */
+    if (!params.skip_resistome) {
+        resistome(
+            full_meta_ch,
+            kneaddata.out.fastq,
+            card_db.out.card_db.collect())
     }
 
     /*
@@ -340,6 +356,14 @@ workflow {
         finished_ch = finished_ch
             .map { meta -> tuple(meta.sample, meta) }
             .join(bracken_full.out.meta.map { meta -> tuple(meta.sample, meta) })
+            .map { sample_id, meta1, meta2 -> meta1 }
+    }
+
+    if (!params.skip_resistome) {
+        // Gate completion on the full-branch resistome profiling.
+        finished_ch = finished_ch
+            .map { meta -> tuple(meta.sample, meta) }
+            .join(resistome.out.meta.map { meta -> tuple(meta.sample, meta) })
             .map { sample_id, meta1, meta2 -> meta1 }
     }
 

--- a/modules/processes/databases.nf
+++ b/modules/processes/databases.nf
@@ -210,6 +210,38 @@ process kraken_db {
     """
 }
 
+process card_db {
+    label 'db_setup'
+    label 'download_retry'
+
+    cpus 1
+    memory "2g"
+
+    storeDir "${params.store_dir}"
+
+    output:
+    path "card_db", emit: card_db, type: 'dir'
+    path ".command*"
+
+    stub:
+    """
+    mkdir -p card_db
+    touch card_db/card.json
+    touch .command.run
+    """
+
+    script:
+    """
+    echo ${PWD}
+    mkdir -p card_db
+    # The canonical CARD data is a bzip2 tarball containing card.json and the
+    # ontology index files; extract it all into card_db/.
+    curl -fsSL "${params.card_db_url}" -o card_data.tar.bz2
+    tar -xjf card_data.tar.bz2 -C card_db
+    rm -f card_data.tar.bz2
+    """
+}
+
 process kneaddata_human_database {
     label 'db_setup'
     label 'download_retry'

--- a/modules/processes/resistome.nf
+++ b/modules/processes/resistome.nf
@@ -1,0 +1,79 @@
+/*
+ * Resistome profiling: RGI against CARD (ADR-0007)
+ *
+ * RGI's read-based `bwt` workflow aligns the host-decontaminated reads against
+ * the CARD reference and reports antimicrobial-resistance gene and allele
+ * abundances, assembly-free. Runs on the full-depth branch only (ARGs are rare;
+ * the rarefied depth yields a sparse, low-value resistome).
+ *
+ * Container and resources are set in the process body (not conf/base.config) to
+ * stay consistent with the other tool-specific processes that override the base
+ * image (e.g. kraken2/bracken).
+ *
+ * NOTE: The RGI load + bwt invocation follows the CARD documentation but is not
+ * exercised by the stub tests (which do not run containers); the first real run
+ * is the true validation. See docs/adr/0007-resistome-rgi-card.md.
+ */
+
+process resistome {
+    container 'docker://quay.io/biocontainers/rgi:6.0.5--pyha8f3691_0'
+
+    label 'profiling'
+
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/${meta.branch ? meta.branch + '/' : ''}resistome", pattern: "{*.txt.gz,.command*}", mode: "${params.publish_mode}"
+
+    tag "${meta.sample}"
+
+    cpus 8
+    memory { 16.GB * task.attempt }
+
+    input:
+    val meta
+    path reads
+    path card_db
+
+    output:
+    val(meta), emit: meta
+    path "rgi_bwt.gene_mapping_data.txt.gz", emit: gene_mapping
+    path "rgi_bwt.allele_mapping_data.txt.gz", emit: allele_mapping
+    path "rgi_bwt.*mapping_stats.txt.gz"
+    path ".command*"
+    path "versions.yml", emit: versions
+
+    stub:
+    """
+    touch rgi_bwt.gene_mapping_data.txt.gz
+    touch rgi_bwt.allele_mapping_data.txt.gz
+    touch rgi_bwt.overall_mapping_stats.txt.gz
+    touch .command.run
+    touch versions.yml
+    """
+
+    script:
+    """
+    # Load CARD canonical data into a run-local database (--local writes a
+    # localDB/ in the work dir, so no writable package install is required).
+    rgi load --card_json ${card_db}/card.json --local
+
+    # Build and load the bwt reference annotation; card_annotation writes a
+    # version-stamped FASTA (card_database_v<CARD version>.fasta).
+    rgi card_annotation -i ${card_db}/card.json
+    card_fasta=\$(ls card_database_v*.fasta | grep -v '_all' | head -n 1)
+    rgi load --card_json ${card_db}/card.json --card_annotation "\$card_fasta" --local
+
+    rgi bwt \
+        --read_one ${reads} \
+        --aligner ${params.rgi_aligner} \
+        --threads ${task.cpus} \
+        --output_file rgi_bwt \
+        --local \
+        --clean
+
+    gzip rgi_bwt.*.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        rgi: \$( rgi main --version 2>&1 | tail -n 1 )
+    END_VERSIONS
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -94,6 +94,22 @@ params {
     bracken_read_length = 100
 
     /*
+     * Resistome profiling: RGI against CARD (ADR-0007)
+     *
+     * When skip_resistome is false (the default), the host-decontaminated reads
+     * are profiled for antimicrobial-resistance genes with RGI's read-based
+     * `bwt` workflow against the CARD database. This runs on the full-depth
+     * branch only (ARGs are rare; the rarefied 1M-read depth yields a sparse,
+     * low-value resistome), and publishes under a `resistome` subdirectory.
+     *
+     * card_db_url is the canonical CARD data tarball; it is downloaded once into
+     * store_dir. rgi_aligner selects the bwt read aligner (bowtie2|bwa|kma).
+     */
+    skip_resistome = false
+    card_db_url = 'https://card.mcmaster.ca/latest/data'
+    rgi_aligner = 'bowtie2'
+
+    /*
      * HUMAnN parameters
      *
      * The HUMAnN branch is currently disabled by default because the active

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -104,6 +104,21 @@
             "default": 100,
             "description": "Bracken read length; must have a matching kmer distribution in the Kraken2 DB."
         },
+        "skip_resistome": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip RGI/CARD read-based resistome profiling."
+        },
+        "card_db_url": {
+            "type": "string",
+            "default": "https://card.mcmaster.ca/latest/data",
+            "description": "URL of the canonical CARD data tarball for RGI."
+        },
+        "rgi_aligner": {
+            "type": "string",
+            "default": "bowtie2",
+            "description": "Read aligner used by RGI bwt (bowtie2, bwa, or kma)."
+        },
         "metadata_tsv": {
             "type": "string",
             "description": "The path to a tab-delimited sample sheet. This file MUST have columns: `study_name`, `sample_id`, and `NCBI_accessions`. The `NCBI_accessions` column should have SRA run accessions separated by `;`."

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -62,6 +62,25 @@ nextflow_pipeline {
         }
     }
 
+    test("Single-sample stub run completes with resistome disabled") {
+
+        when {
+            params {
+                sample_id = "TEST_SAMPLE"
+                run_ids = "SRR000001"
+                skip_humann = true
+                skip_resistome = true
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.failed == false
+            assert workflow.exitStatus == 0
+            assert workflow.errorReport == null || workflow.errorReport.isEmpty()
+        }
+    }
+
     test("Missing sample arguments fails fast with a clear error") {
 
         when {


### PR DESCRIPTION
Implements **ADR-0007** — the final read-based item on the roadmap. Adds antimicrobial-resistance gene profiling, completing the read-based enhancement set (manifest → Kraken2/Bracken → resistome).

## What it does

When `skip_resistome=false` (default), the host-decontaminated reads are profiled with **RGI's read-based `bwt` workflow against CARD**, emitting per-sample gene- and allele-level AMR mapping tables under a `resistome/` subdirectory:

```
<sample>/full_data/resistome/{rgi_bwt.gene_mapping_data.txt.gz, rgi_bwt.allele_mapping_data.txt.gz, rgi_bwt.*mapping_stats.txt.gz}
```

## Choices (per your answers)

- **Full-depth branch only** — ARGs are rare and the rarefied 1M-read depth gives a sparse, low-value resistome. It keeps the **conventional branch-aware publishDir** (not HUMAnN's flat path), so with rarefaction active it lands in `full_data/resistome/`.
- **Opt-out (default on)** via `skip_resistome`, consistent with `skip_gtdb`/`skip_kraken`.
- RGI `bwt` with `--read_one` (the pipeline is single-end throughout); `rgi_aligner` defaults to `bowtie2`. CARD downloaded once into `store_dir`. Container + resources set in the process body, matching the kraken convention.

## Testing
- `just test-nf` — 7/7 pass (added a `skip_resistome=true` stub case).
- `just test-stub` — full DAG runs; `card_db` and `resistome` execute and publish into `full_data/resistome/`.
- `just test-config-all` — all profiles resolve.

## ⚠️ Review caveat (same class as the Kraken PR)
The RGI command sequence (`rgi load --local` → `rgi card_annotation` → `rgi bwt`) follows the CARD docs but **is not exercised by stub tests** (no containers run), so the first real run is the true validation. Two things to confirm on a real sample:
1. The biocontainer build suffix `quay.io/biocontainers/rgi:6.0.5--pyha8f3691_0` (verify against current quay.io tags).
2. The `card_annotation` FASTA glob and `rgi bwt` single-end invocation behave as written for RGI 6.0.5.

Both are isolated to `resistome.nf` / config and easy to adjust.

This completes ADRs 0004–0007. Branched off `main` after #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)