### PR TITLE
Per-sample post-decontamination FastQC (ADR-0008)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ nextflow run main.nf -profile local --metadata_tsv samples.tsv
 | `gtdb.nf` | `metaphlan_to_gtdb` (SGB→GTDB profile conversion) |
 | `kraken.nf` | `kraken2`, `bracken` (complementary read-based profiling) |
 | `resistome.nf` | `resistome` (RGI/CARD read-based AMR profiling, full branch only) |
+| `qc.nf` | `fastqc` (post-decontamination), `multiqc` (per-sample QC report) |
 | `manifest.nf` | `sample_manifest` (per-sample provenance + read-accounting `manifest.json`) |
 | `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB, Kraken2, CARD DBs) |
 | `humann.nf` | HUMAnN gene/pathway abundance (disabled by default) |
@@ -53,6 +54,8 @@ GTDB conversion uses the vendored `bin/sgb_to_gtdb_profile.py` (Nextflow stages 
 `kraken2`/`bracken` (module `kraken.nf`, gated by `skip_kraken`) add a complementary read-based profile under each branch's `kraken/` subdirectory. They use per-process StaPH-B containers and set all directives (container, resources, `maxForks`) **in the process body** rather than `conf/base.config`, because they are imported under aliases. The Kraken2 DB is loaded into RAM (default mode, not memory-mapped or staged to scratch) for cluster portability; `kraken_maxforks` throttles concurrent reads of the DB off shared storage. See ADR-0006.
 
 `resistome` (module `resistome.nf`, gated by `skip_resistome`) runs RGI's read-based `bwt` workflow against CARD, publishing AMR gene/allele mapping tables under a `resistome/` subdirectory. It runs on the **full branch only** (ARGs are sparse at the rarefied depth) but keeps the branch-aware publishDir, so with rarefaction active it lands in `full_data/resistome/`. Container/resources are set in the process body. The RGI command sequence is not exercised by stub tests; validate it on a real sample. See ADR-0007.
+
+`fastqc`/`multiqc` (module `qc.nf`, gated by `skip_multiqc`) add per-sample QC reporting: raw-read FastQC already runs in `fasterq_dump`/`local_fastqc`, so `fastqc` here covers the **decontaminated** reads (`<sample>/fastqc/`), and `multiqc` aggregates the raw + decontaminated FastQC into `<sample>/multiqc/multiqc_report.html`. The two FastQC reports are staged into `raw/` and `clean/` and MultiQC is run with `--dirs` to keep their identical sample names distinct. Per-sample only (no cross-sample aggregation). MultiQC uses a pinned biocontainer (verify the tag on a real run). See ADR-0008.
 
 ### Architecture Decision Records
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ nextflow run main.nf -profile local --metadata_tsv samples.tsv
 | `gtdb.nf` | `metaphlan_to_gtdb` (SGB→GTDB profile conversion) |
 | `kraken.nf` | `kraken2`, `bracken` (complementary read-based profiling) |
 | `resistome.nf` | `resistome` (RGI/CARD read-based AMR profiling, full branch only) |
-| `qc.nf` | `fastqc` (post-decontamination), `multiqc` (per-sample QC report) |
+| `qc.nf` | `fastqc` (post-decontamination FastQC) |
 | `manifest.nf` | `sample_manifest` (per-sample provenance + read-accounting `manifest.json`) |
 | `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB, Kraken2, CARD DBs) |
 | `humann.nf` | HUMAnN gene/pathway abundance (disabled by default) |
@@ -55,7 +55,7 @@ GTDB conversion uses the vendored `bin/sgb_to_gtdb_profile.py` (Nextflow stages 
 
 `resistome` (module `resistome.nf`, gated by `skip_resistome`) runs RGI's read-based `bwt` workflow against CARD, publishing AMR gene/allele mapping tables under a `resistome/` subdirectory. It runs on the **full branch only** (ARGs are sparse at the rarefied depth) but keeps the branch-aware publishDir, so with rarefaction active it lands in `full_data/resistome/`. Container/resources are set in the process body. The RGI command sequence is not exercised by stub tests; validate it on a real sample. See ADR-0007.
 
-`fastqc`/`multiqc` (module `qc.nf`, gated by `skip_multiqc`) add per-sample QC reporting: raw-read FastQC already runs in `fasterq_dump`/`local_fastqc`, so `fastqc` here covers the **decontaminated** reads (`<sample>/fastqc/`), and `multiqc` aggregates the raw + decontaminated FastQC into `<sample>/multiqc/multiqc_report.html`. The two FastQC reports are staged into `raw/` and `clean/` and MultiQC is run with `--dirs` to keep their identical sample names distinct. Per-sample only (no cross-sample aggregation). MultiQC uses a pinned biocontainer (verify the tag on a real run). See ADR-0008.
+`fastqc` (module `qc.nf`, gated by `skip_fastqc`) runs FastQC on the **decontaminated** reads (`<sample>/fastqc/`); raw-read FastQC already runs in `fasterq_dump`/`local_fastqc`, so this gives a before/after view. It runs in the base image (no new container). A per-sample MultiQC report was considered but dropped to avoid introducing another container (see ADR-0008). Per-sample only.
 
 ### Architecture Decision Records
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ nextflow run main.nf --metadata_tsv samples.tsv --skip_humann --publish_base_dir
 | `skip_gtdb`      | Skip MetaPhlAn-to-GTDB profile conversion | `false` |
 | `skip_kraken`    | Skip Kraken2 + Bracken read-based profiling | `false` |
 | `skip_resistome` | Skip RGI/CARD resistome profiling (full branch only) | `false` |
-| `skip_multiqc`   | Skip post-decontamination FastQC + per-sample MultiQC report | `false` |
+| `skip_fastqc`    | Skip FastQC on the host-decontaminated reads | `false` |
 
 `skip_humann=true` is the current supported default. The `skip_humann=false`
 path is kept in the pipeline for future use, but it is not expected to work
@@ -178,21 +178,17 @@ This step runs on the **full-depth branch only** — ARGs are rare and the raref
 active it publishes under `full_data/resistome/`. See
 [`docs/adr/0007-resistome-rgi-card.md`](docs/adr/0007-resistome-rgi-card.md).
 
-### QC Reporting Parameters
+### QC Parameters
 
-| Parameter      | Description                                                       | Default |
-| -------------- | ----------------------------------------------------------------- | ------- |
-| `skip_multiqc` | Disable post-decontamination FastQC and the per-sample MultiQC report | `false` |
+| Parameter     | Description                                          | Default |
+| ------------- | ---------------------------------------------------- | ------- |
+| `skip_fastqc` | Disable FastQC on the host-decontaminated reads      | `false` |
 
 Raw-read FastQC already runs in both input modes (inside `fasterq_dump` /
-`local_fastqc`). When `skip_multiqc=false` (the default), the pipeline also runs
-FastQC on the **host-decontaminated** reads (published under `<sample>/fastqc/`)
-and a per-sample [MultiQC](https://multiqc.info/) report aggregating the raw and
-post-decontamination FastQC into `<sample>/multiqc/multiqc_report.html`. The two
-FastQC reports are staged into `raw/` and `clean/` and MultiQC is run with
-`--dirs` so their (otherwise identical) sample names stay distinct.
-
-This is **per-sample only** — no cross-sample aggregation. See
+`local_fastqc`). When `skip_fastqc=false` (the default), the pipeline also runs
+FastQC on the **host-decontaminated** reads, published under `<sample>/fastqc/`,
+giving a before/after view of what QC did to the reads. It runs in the base
+image, so no additional container is required. Per-sample only. See
 [`docs/adr/0008-per-sample-qc-reporting.md`](docs/adr/0008-per-sample-qc-reporting.md).
 
 ### HUMAnN Parameters
@@ -243,8 +239,7 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── manifest.json     (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE
 │   │   │   ├── kneaddata/
-│   │   │   ├── fastqc/           (decontaminated-read FastQC; only when --skip_multiqc false)
-│   │   │   ├── multiqc/          (per-sample report; only when --skip_multiqc false)
+│   │   │   ├── fastqc/           (decontaminated-read FastQC; only when --skip_fastqc false)
 │   │   │   ├── full_data/
 │   │   │   │   ├── metaphlan_lists/
 │   │   │   │   ├── metaphlan_markers/
@@ -273,8 +268,7 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── manifest.json   (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE
 │   │   │   ├── kneaddata/
-│   │   │   ├── fastqc/         (decontaminated-read FastQC; only when --skip_multiqc false)
-│   │   │   ├── multiqc/        (per-sample report; only when --skip_multiqc false)
+│   │   │   ├── fastqc/         (decontaminated-read FastQC; only when --skip_fastqc false)
 │   │   │   ├── metaphlan_lists/
 │   │   │   ├── metaphlan_markers/
 │   │   │   ├── strainphlan_markers/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ nextflow run main.nf --metadata_tsv samples.tsv --skip_humann --publish_base_dir
 | `skip_gtdb`      | Skip MetaPhlAn-to-GTDB profile conversion | `false` |
 | `skip_kraken`    | Skip Kraken2 + Bracken read-based profiling | `false` |
 | `skip_resistome` | Skip RGI/CARD resistome profiling (full branch only) | `false` |
+| `skip_multiqc`   | Skip post-decontamination FastQC + per-sample MultiQC report | `false` |
 
 `skip_humann=true` is the current supported default. The `skip_humann=false`
 path is kept in the pipeline for future use, but it is not expected to work
@@ -177,6 +178,23 @@ This step runs on the **full-depth branch only** — ARGs are rare and the raref
 active it publishes under `full_data/resistome/`. See
 [`docs/adr/0007-resistome-rgi-card.md`](docs/adr/0007-resistome-rgi-card.md).
 
+### QC Reporting Parameters
+
+| Parameter      | Description                                                       | Default |
+| -------------- | ----------------------------------------------------------------- | ------- |
+| `skip_multiqc` | Disable post-decontamination FastQC and the per-sample MultiQC report | `false` |
+
+Raw-read FastQC already runs in both input modes (inside `fasterq_dump` /
+`local_fastqc`). When `skip_multiqc=false` (the default), the pipeline also runs
+FastQC on the **host-decontaminated** reads (published under `<sample>/fastqc/`)
+and a per-sample [MultiQC](https://multiqc.info/) report aggregating the raw and
+post-decontamination FastQC into `<sample>/multiqc/multiqc_report.html`. The two
+FastQC reports are staged into `raw/` and `clean/` and MultiQC is run with
+`--dirs` so their (otherwise identical) sample names stay distinct.
+
+This is **per-sample only** — no cross-sample aggregation. See
+[`docs/adr/0008-per-sample-qc-reporting.md`](docs/adr/0008-per-sample-qc-reporting.md).
+
 ### HUMAnN Parameters
 
 | Parameter    | Description                 | Default            |
@@ -225,6 +243,8 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── manifest.json     (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE
 │   │   │   ├── kneaddata/
+│   │   │   ├── fastqc/           (decontaminated-read FastQC; only when --skip_multiqc false)
+│   │   │   ├── multiqc/          (per-sample report; only when --skip_multiqc false)
 │   │   │   ├── full_data/
 │   │   │   │   ├── metaphlan_lists/
 │   │   │   │   ├── metaphlan_markers/
@@ -253,6 +273,8 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   ├── manifest.json   (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE
 │   │   │   ├── kneaddata/
+│   │   │   ├── fastqc/         (decontaminated-read FastQC; only when --skip_multiqc false)
+│   │   │   ├── multiqc/        (per-sample report; only when --skip_multiqc false)
 │   │   │   ├── metaphlan_lists/
 │   │   │   ├── metaphlan_markers/
 │   │   │   ├── strainphlan_markers/

--- a/docs/adr/0008-per-sample-qc-reporting.md
+++ b/docs/adr/0008-per-sample-qc-reporting.md
@@ -1,4 +1,4 @@
-# 0008. Per-sample QC reporting: post-decontamination FastQC + MultiQC
+# 0008. Per-sample post-decontamination FastQC
 
 - **Status:** Accepted (implemented)
 - **Date:** 2026-06-03
@@ -8,54 +8,38 @@
 
 Before a full-scale run we want a quick, per-sample quality-control view. Raw-read
 FastQC already runs in **both** input modes (embedded in `fasterq_dump` and
-`local_fastqc`), so that is not the gap. What is missing:
-
-1. No FastQC on the reads that actually feed profiling — i.e. after
-   KneadData host decontamination and trimming. Without it there is no
-   before/after view of what QC did to the reads.
-2. No consolidated, human-readable per-sample QC report; the FastQC outputs and
-   logs are scattered across subdirectories.
+`local_fastqc`), so that is not the gap. What is missing is FastQC on the reads
+that actually feed profiling — i.e. after KneadData host decontamination and
+trimming — so there is no before/after view of what QC did to the reads.
 
 ## Decision
 
-Add two steps, both **per-sample only** (no cross-sample aggregation — that is a
-separate downstream concern and explicitly out of scope here):
-
-1. A **FastQC pass on the host-decontaminated reads** (`fastqc` in
-   `modules/processes/qc.nf`), published under `<sample>/fastqc/`.
-2. A **per-sample MultiQC** (`multiqc`) that aggregates the raw and
-   post-decontamination FastQC into one `multiqc_report.html` (+ data) under
-   `<sample>/multiqc/`. The two FastQC reports are staged into `raw/` and
-   `clean/` subdirectories and MultiQC is run with `--dirs` so the otherwise
-   identical FastQC sample names are disambiguated.
-
-Both are gated by `skip_multiqc` (default false, opt-out, consistent with the
-other optional steps). FastQC runs in the base image; MultiQC uses a pinned
-biocontainer (per [0001](0001-container-strategy.md)).
+Add a **FastQC pass on the host-decontaminated reads** (`fastqc` in
+`modules/processes/qc.nf`), published under `<sample>/fastqc/`. It runs in the
+base image (FastQC is already present), so **no additional container** is
+introduced. Gated by `skip_fastqc` (default false, opt-out). Per-sample only.
 
 ## Alternatives considered
 
-- **Cross-sample MultiQC** (the usual way MultiQC is used) — explicitly out of
-  scope: this is a per-sample pipeline; any across-sample reporting is handled
-  later, downstream.
-- **Re-run raw FastQC inside the QC module** for symmetry — wasteful; the raw
-  FastQC already exists, so MultiQC consumes it directly rather than recomputing.
-- **Feed Kraken2/Bracken/MetaPhlAn into MultiQC now** — deferred. v1 keeps the
-  report to the FastQC before/after to stay low-risk; the MultiQC input set can
-  be widened later (MultiQC has Kraken modules).
+- **Add a per-sample MultiQC report** aggregating the raw + post-decontamination
+  FastQC. Considered and **rejected for now**: MultiQC is not in the base image,
+  and adding another container is not worth it for a per-sample report over just
+  two FastQC outputs. The raw and post-decontamination FastQC reports remain
+  available individually under the sample directory.
+- **Cross-sample MultiQC** — out of scope; this is a per-sample pipeline.
+- **Re-run raw FastQC inside this module for symmetry** — wasteful; raw FastQC
+  already exists upstream.
 
 ## Consequences
 
-- Each sample gets a before/after read-QC report in one HTML, plus a FastQC
-  profile of the decontaminated reads.
-- New MultiQC container; its exact biocontainer tag is **not exercised by stub
-  tests** (no containers run there), so confirm it on the first real run — same
-  caveat class as the Kraken/RGI containers.
-- The MultiQC input set is intentionally minimal for now; widening it (Kraken,
-  etc.) is future work, not a new architectural decision.
+- Each sample gets a FastQC profile of the decontaminated reads alongside the
+  existing raw-read FastQC, giving a before/after without any new dependency.
+- No consolidated single-file QC report; consumers read the two FastQC outputs
+  (or aggregate them downstream). Revisiting MultiQC later would mean accepting a
+  new container.
 
 ## References
 
 - ADR [0001](0001-container-strategy.md) (per-process container).
-- Implemented in: `modules/processes/qc.nf` (`fastqc`, `multiqc`), `main.nf`
-  wiring, `nextflow.config` (`skip_multiqc`).
+- Implemented in: `modules/processes/qc.nf` (`fastqc`), `main.nf` wiring,
+  `nextflow.config` (`skip_fastqc`).

--- a/docs/adr/0008-per-sample-qc-reporting.md
+++ b/docs/adr/0008-per-sample-qc-reporting.md
@@ -1,0 +1,61 @@
+# 0008. Per-sample QC reporting: post-decontamination FastQC + MultiQC
+
+- **Status:** Accepted (implemented)
+- **Date:** 2026-06-03
+- **Deciders:** Sean Davis
+
+## Context
+
+Before a full-scale run we want a quick, per-sample quality-control view. Raw-read
+FastQC already runs in **both** input modes (embedded in `fasterq_dump` and
+`local_fastqc`), so that is not the gap. What is missing:
+
+1. No FastQC on the reads that actually feed profiling — i.e. after
+   KneadData host decontamination and trimming. Without it there is no
+   before/after view of what QC did to the reads.
+2. No consolidated, human-readable per-sample QC report; the FastQC outputs and
+   logs are scattered across subdirectories.
+
+## Decision
+
+Add two steps, both **per-sample only** (no cross-sample aggregation — that is a
+separate downstream concern and explicitly out of scope here):
+
+1. A **FastQC pass on the host-decontaminated reads** (`fastqc` in
+   `modules/processes/qc.nf`), published under `<sample>/fastqc/`.
+2. A **per-sample MultiQC** (`multiqc`) that aggregates the raw and
+   post-decontamination FastQC into one `multiqc_report.html` (+ data) under
+   `<sample>/multiqc/`. The two FastQC reports are staged into `raw/` and
+   `clean/` subdirectories and MultiQC is run with `--dirs` so the otherwise
+   identical FastQC sample names are disambiguated.
+
+Both are gated by `skip_multiqc` (default false, opt-out, consistent with the
+other optional steps). FastQC runs in the base image; MultiQC uses a pinned
+biocontainer (per [0001](0001-container-strategy.md)).
+
+## Alternatives considered
+
+- **Cross-sample MultiQC** (the usual way MultiQC is used) — explicitly out of
+  scope: this is a per-sample pipeline; any across-sample reporting is handled
+  later, downstream.
+- **Re-run raw FastQC inside the QC module** for symmetry — wasteful; the raw
+  FastQC already exists, so MultiQC consumes it directly rather than recomputing.
+- **Feed Kraken2/Bracken/MetaPhlAn into MultiQC now** — deferred. v1 keeps the
+  report to the FastQC before/after to stay low-risk; the MultiQC input set can
+  be widened later (MultiQC has Kraken modules).
+
+## Consequences
+
+- Each sample gets a before/after read-QC report in one HTML, plus a FastQC
+  profile of the decontaminated reads.
+- New MultiQC container; its exact biocontainer tag is **not exercised by stub
+  tests** (no containers run there), so confirm it on the first real run — same
+  caveat class as the Kraken/RGI containers.
+- The MultiQC input set is intentionally minimal for now; widening it (Kraken,
+  etc.) is future work, not a new architectural decision.
+
+## References
+
+- ADR [0001](0001-container-strategy.md) (per-process container).
+- Implemented in: `modules/processes/qc.nf` (`fastqc`, `multiqc`), `main.nf`
+  wiring, `nextflow.config` (`skip_multiqc`).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,4 +55,4 @@ other. This preserves the historical record rather than rewriting it.
 | [0005](0005-per-sample-manifest.md) | Per-sample provenance & read-accounting manifest | Accepted |
 | [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted |
 | [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted |
-| [0008](0008-per-sample-qc-reporting.md) | Per-sample QC reporting: post-decontamination FastQC + MultiQC | Accepted |
+| [0008](0008-per-sample-qc-reporting.md) | Per-sample post-decontamination FastQC | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,4 @@ other. This preserves the historical record rather than rewriting it.
 | [0005](0005-per-sample-manifest.md) | Per-sample provenance & read-accounting manifest | Accepted |
 | [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted |
 | [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted |
+| [0008](0008-per-sample-qc-reporting.md) | Per-sample QC reporting: post-decontamination FastQC + MultiQC | Accepted |

--- a/main.nf
+++ b/main.nf
@@ -49,6 +49,7 @@ include {
     bracken as bracken_rarefied
 } from './modules/processes/kraken'
 include { resistome } from './modules/processes/resistome'
+include { fastqc; multiqc } from './modules/processes/qc'
 include { humann } from './modules/processes/humann'
 include { sample_manifest } from './modules/processes/manifest'
 include { MARK_COMPLETE } from './modules/processes/finalize'
@@ -153,6 +154,7 @@ workflow {
         raw_fastq_ch = local_fastqc.out.fastq
         raw_versions_ch = local_fastqc.out.versions
         raw_meta_ch = local_fastqc.out.meta
+        raw_fastqc_ch = local_fastqc.out.fastqc_data
         kneaddata(
             local_fastqc.out.meta,
             local_fastqc.out.fastq,
@@ -162,6 +164,7 @@ workflow {
         raw_fastq_ch = fasterq_dump.out.fastq
         raw_versions_ch = fasterq_dump.out.versions
         raw_meta_ch = fasterq_dump.out.meta
+        raw_fastqc_ch = fasterq_dump.out.fastqc_data
         kneaddata(
             fasterq_dump.out.meta,
             fasterq_dump.out.fastq,
@@ -233,6 +236,31 @@ workflow {
             full_meta_ch,
             kneaddata.out.fastq,
             card_db.out.card_db.collect())
+    }
+
+    /*
+     * Per-sample QC reporting: FastQC on the decontaminated reads, then a
+     * MultiQC report aggregating the raw and post-decontamination FastQC.
+     * Joined by sample so each MultiQC run sees exactly its sample's two reports.
+     */
+    if (!params.skip_multiqc) {
+        fastqc(
+            kneaddata.out.meta,
+            kneaddata.out.fastq)
+
+        raw_fastqc_by_sample = raw_meta_ch
+            .merge(raw_fastqc_ch)
+            .map { m, fqc -> tuple(m.sample, fqc) }
+
+        clean_fastqc_by_sample = fastqc.out.meta
+            .merge(fastqc.out.fastqc_data)
+            .map { m, fqc -> tuple(m.sample, m, fqc) }
+
+        multiqc_input = clean_fastqc_by_sample
+            .join(raw_fastqc_by_sample)
+            .map { sample, meta, clean_fqc, raw_fqc -> tuple(meta, raw_fqc, clean_fqc) }
+
+        multiqc(multiqc_input)
     }
 
     /*
@@ -364,6 +392,14 @@ workflow {
         finished_ch = finished_ch
             .map { meta -> tuple(meta.sample, meta) }
             .join(resistome.out.meta.map { meta -> tuple(meta.sample, meta) })
+            .map { sample_id, meta1, meta2 -> meta1 }
+    }
+
+    if (!params.skip_multiqc) {
+        // Gate completion on the per-sample MultiQC report.
+        finished_ch = finished_ch
+            .map { meta -> tuple(meta.sample, meta) }
+            .join(multiqc.out.meta.map { meta -> tuple(meta.sample, meta) })
             .map { sample_id, meta1, meta2 -> meta1 }
     }
 

--- a/main.nf
+++ b/main.nf
@@ -49,7 +49,7 @@ include {
     bracken as bracken_rarefied
 } from './modules/processes/kraken'
 include { resistome } from './modules/processes/resistome'
-include { fastqc; multiqc } from './modules/processes/qc'
+include { fastqc } from './modules/processes/qc'
 include { humann } from './modules/processes/humann'
 include { sample_manifest } from './modules/processes/manifest'
 include { MARK_COMPLETE } from './modules/processes/finalize'
@@ -154,7 +154,6 @@ workflow {
         raw_fastq_ch = local_fastqc.out.fastq
         raw_versions_ch = local_fastqc.out.versions
         raw_meta_ch = local_fastqc.out.meta
-        raw_fastqc_ch = local_fastqc.out.fastqc_data
         kneaddata(
             local_fastqc.out.meta,
             local_fastqc.out.fastq,
@@ -164,7 +163,6 @@ workflow {
         raw_fastq_ch = fasterq_dump.out.fastq
         raw_versions_ch = fasterq_dump.out.versions
         raw_meta_ch = fasterq_dump.out.meta
-        raw_fastqc_ch = fasterq_dump.out.fastqc_data
         kneaddata(
             fasterq_dump.out.meta,
             fasterq_dump.out.fastq,
@@ -239,28 +237,13 @@ workflow {
     }
 
     /*
-     * Per-sample QC reporting: FastQC on the decontaminated reads, then a
-     * MultiQC report aggregating the raw and post-decontamination FastQC.
-     * Joined by sample so each MultiQC run sees exactly its sample's two reports.
+     * Per-sample QC: FastQC on the host-decontaminated reads (raw-read FastQC
+     * already runs in fasterq_dump/local_fastqc).
      */
-    if (!params.skip_multiqc) {
+    if (!params.skip_fastqc) {
         fastqc(
             kneaddata.out.meta,
             kneaddata.out.fastq)
-
-        raw_fastqc_by_sample = raw_meta_ch
-            .merge(raw_fastqc_ch)
-            .map { m, fqc -> tuple(m.sample, fqc) }
-
-        clean_fastqc_by_sample = fastqc.out.meta
-            .merge(fastqc.out.fastqc_data)
-            .map { m, fqc -> tuple(m.sample, m, fqc) }
-
-        multiqc_input = clean_fastqc_by_sample
-            .join(raw_fastqc_by_sample)
-            .map { sample, meta, clean_fqc, raw_fqc -> tuple(meta, raw_fqc, clean_fqc) }
-
-        multiqc(multiqc_input)
     }
 
     /*
@@ -395,11 +378,11 @@ workflow {
             .map { sample_id, meta1, meta2 -> meta1 }
     }
 
-    if (!params.skip_multiqc) {
-        // Gate completion on the per-sample MultiQC report.
+    if (!params.skip_fastqc) {
+        // Gate completion on the post-decontamination FastQC.
         finished_ch = finished_ch
             .map { meta -> tuple(meta.sample, meta) }
-            .join(multiqc.out.meta.map { meta -> tuple(meta.sample, meta) })
+            .join(fastqc.out.meta.map { meta -> tuple(meta.sample, meta) })
             .map { sample_id, meta1, meta2 -> meta1 }
     }
 

--- a/modules/processes/qc.nf
+++ b/modules/processes/qc.nf
@@ -1,0 +1,102 @@
+/*
+ * Per-sample QC reporting (ADR-0008)
+ *
+ * fastqc: FastQC on the host-decontaminated reads (raw-read FastQC already runs
+ *   in fasterq_dump/local_fastqc), giving a post-QC view of the reads that feed
+ *   profiling.
+ * multiqc: aggregate the raw and post-decontamination FastQC into one
+ *   per-sample report. The two FastQC outputs are staged into raw/ and clean/
+ *   subdirectories and MultiQC is run with --dirs so their (otherwise identical)
+ *   sample names are disambiguated.
+ *
+ * Per-sample only — no cross-sample aggregation.
+ */
+
+process fastqc {
+    label 'qc'
+
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/fastqc", pattern: "{*_fastqc.zip,*_fastqc/fastqc_data.txt,.command*}", mode: "${params.publish_mode}"
+
+    tag "${meta.sample}"
+
+    cpus 2
+    memory { 4.GB * task.attempt }
+
+    input:
+    val meta
+    path reads
+
+    output:
+    val(meta), emit: meta
+    path "*_fastqc/fastqc_data.txt", emit: fastqc_data
+    path "*_fastqc.zip"
+    path ".command*"
+    path "versions.yml", emit: versions
+
+    stub:
+    """
+    mkdir -p decontaminated_fastqc
+    touch decontaminated_fastqc/fastqc_data.txt
+    touch decontaminated_fastqc.zip
+    touch .command.run
+    touch versions.yml
+    """
+
+    script:
+    """
+    # Name the FastQC output after the sample stage so the report is clearly the
+    # decontaminated reads rather than a generic "out".
+    ln -s ${reads} decontaminated.fastq
+    fastqc --extract decontaminated.fastq
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        fastqc: \$( echo \$(fastqc --version 2>&1 ) | sed 's/^.*FastQC //' )
+    END_VERSIONS
+    """
+}
+
+process multiqc {
+    container 'docker://quay.io/biocontainers/multiqc:1.35--pyhdfd78af_0'
+
+    label 'qc'
+
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/multiqc", pattern: "{multiqc_report.html,multiqc_report_data/**,.command*}", mode: "${params.publish_mode}"
+
+    tag "${meta.sample}"
+
+    cpus 1
+    memory { 4.GB * task.attempt }
+
+    input:
+    tuple val(meta),
+          path(raw_fastqc, stageAs: 'raw/fastqc_data.txt'),
+          path(clean_fastqc, stageAs: 'clean/fastqc_data.txt')
+
+    output:
+    val(meta), emit: meta
+    path "multiqc_report.html", emit: report
+    path "multiqc_report_data", type: 'dir'
+    path ".command*"
+    path "versions.yml", emit: versions
+
+    stub:
+    """
+    touch multiqc_report.html
+    mkdir -p multiqc_report_data
+    touch .command.run
+    touch versions.yml
+    """
+
+    script:
+    """
+    # --dirs prepends the raw/ and clean/ directory names to the FastQC sample
+    # names so the two reports (both named for the same read file) stay distinct.
+    multiqc --dirs --dirs-depth 1 --force --no-ansi -n multiqc_report .
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        multiqc: \$( multiqc --version 2>&1 | awk '{print \$NF}' )
+    END_VERSIONS
+    """
+}

--- a/modules/processes/qc.nf
+++ b/modules/processes/qc.nf
@@ -1,15 +1,12 @@
 /*
  * Per-sample QC reporting (ADR-0008)
  *
- * fastqc: FastQC on the host-decontaminated reads (raw-read FastQC already runs
- *   in fasterq_dump/local_fastqc), giving a post-QC view of the reads that feed
- *   profiling.
- * multiqc: aggregate the raw and post-decontamination FastQC into one
- *   per-sample report. The two FastQC outputs are staged into raw/ and clean/
- *   subdirectories and MultiQC is run with --dirs so their (otherwise identical)
- *   sample names are disambiguated.
+ * fastqc: FastQC on the host-decontaminated reads. Raw-read FastQC already runs
+ *   in fasterq_dump/local_fastqc, so this adds a post-QC view of the reads that
+ *   actually feed profiling. Runs in the base image (FastQC is already present),
+ *   so no additional container is required.
  *
- * Per-sample only — no cross-sample aggregation.
+ * Per-sample only.
  */
 
 process fastqc {
@@ -52,51 +49,6 @@ process fastqc {
     cat <<-END_VERSIONS > versions.yml
     versions:
         fastqc: \$( echo \$(fastqc --version 2>&1 ) | sed 's/^.*FastQC //' )
-    END_VERSIONS
-    """
-}
-
-process multiqc {
-    container 'docker://quay.io/biocontainers/multiqc:1.35--pyhdfd78af_0'
-
-    label 'qc'
-
-    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/multiqc", pattern: "{multiqc_report.html,multiqc_report_data/**,.command*}", mode: "${params.publish_mode}"
-
-    tag "${meta.sample}"
-
-    cpus 1
-    memory { 4.GB * task.attempt }
-
-    input:
-    tuple val(meta),
-          path(raw_fastqc, stageAs: 'raw/fastqc_data.txt'),
-          path(clean_fastqc, stageAs: 'clean/fastqc_data.txt')
-
-    output:
-    val(meta), emit: meta
-    path "multiqc_report.html", emit: report
-    path "multiqc_report_data", type: 'dir'
-    path ".command*"
-    path "versions.yml", emit: versions
-
-    stub:
-    """
-    touch multiqc_report.html
-    mkdir -p multiqc_report_data
-    touch .command.run
-    touch versions.yml
-    """
-
-    script:
-    """
-    # --dirs prepends the raw/ and clean/ directory names to the FastQC sample
-    # names so the two reports (both named for the same read file) stay distinct.
-    multiqc --dirs --dirs-depth 1 --force --no-ansi -n multiqc_report .
-
-    cat <<-END_VERSIONS > versions.yml
-    versions:
-        multiqc: \$( multiqc --version 2>&1 | awk '{print \$NF}' )
     END_VERSIONS
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -110,6 +110,17 @@ params {
     rgi_aligner = 'bowtie2'
 
     /*
+     * Per-sample QC reporting (ADR-0008)
+     *
+     * When skip_multiqc is false (the default), FastQC is run on the
+     * host-decontaminated reads (raw-read FastQC already runs in
+     * fasterq_dump/local_fastqc) and a per-sample MultiQC report aggregates the
+     * raw and post-decontamination FastQC into <sample>/multiqc/. Per-sample
+     * only; no cross-sample aggregation.
+     */
+    skip_multiqc = false
+
+    /*
      * HUMAnN parameters
      *
      * The HUMAnN branch is currently disabled by default because the active

--- a/nextflow.config
+++ b/nextflow.config
@@ -110,15 +110,14 @@ params {
     rgi_aligner = 'bowtie2'
 
     /*
-     * Per-sample QC reporting (ADR-0008)
+     * Per-sample QC (ADR-0008)
      *
-     * When skip_multiqc is false (the default), FastQC is run on the
-     * host-decontaminated reads (raw-read FastQC already runs in
-     * fasterq_dump/local_fastqc) and a per-sample MultiQC report aggregates the
-     * raw and post-decontamination FastQC into <sample>/multiqc/. Per-sample
-     * only; no cross-sample aggregation.
+     * When skip_fastqc is false (the default), FastQC is run on the
+     * host-decontaminated reads and published under <sample>/fastqc/. Raw-read
+     * FastQC already runs in fasterq_dump/local_fastqc, so this adds a post-QC
+     * view of the reads that feed profiling. Per-sample only.
      */
-    skip_multiqc = false
+    skip_fastqc = false
 
     /*
      * HUMAnN parameters

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -119,6 +119,11 @@
             "default": "bowtie2",
             "description": "Read aligner used by RGI bwt (bowtie2, bwa, or kma)."
         },
+        "skip_multiqc": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip post-decontamination FastQC and the per-sample MultiQC report."
+        },
         "metadata_tsv": {
             "type": "string",
             "description": "The path to a tab-delimited sample sheet. This file MUST have columns: `study_name`, `sample_id`, and `NCBI_accessions`. The `NCBI_accessions` column should have SRA run accessions separated by `;`."

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -119,10 +119,10 @@
             "default": "bowtie2",
             "description": "Read aligner used by RGI bwt (bowtie2, bwa, or kma)."
         },
-        "skip_multiqc": {
+        "skip_fastqc": {
             "type": "boolean",
             "default": false,
-            "description": "Skip post-decontamination FastQC and the per-sample MultiQC report."
+            "description": "Skip FastQC on the host-decontaminated reads."
         },
         "metadata_tsv": {
             "type": "string",

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -81,6 +81,25 @@ nextflow_pipeline {
         }
     }
 
+    test("Single-sample stub run completes with MultiQC disabled") {
+
+        when {
+            params {
+                sample_id = "TEST_SAMPLE"
+                run_ids = "SRR000001"
+                skip_humann = true
+                skip_multiqc = true
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.failed == false
+            assert workflow.exitStatus == 0
+            assert workflow.errorReport == null || workflow.errorReport.isEmpty()
+        }
+    }
+
     test("Missing sample arguments fails fast with a clear error") {
 
         when {

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -81,14 +81,14 @@ nextflow_pipeline {
         }
     }
 
-    test("Single-sample stub run completes with MultiQC disabled") {
+    test("Single-sample stub run completes with FastQC disabled") {
 
         when {
             params {
                 sample_id = "TEST_SAMPLE"
                 run_ids = "SRR000001"
                 skip_humann = true
-                skip_multiqc = true
+                skip_fastqc = true
             }
         }
 


### PR DESCRIPTION
Implements **ADR-0008** — a low-risk QC addition before the full-scale run.

**Updated per review:** dropped the MultiQC piece to avoid pulling in another container. This now adds **only** the post-decontamination FastQC.

## What it does
Raw-read FastQC already runs in both input modes (embedded in `fasterq_dump`/`local_fastqc`). This adds the missing view: **FastQC on the host-decontaminated reads**, published under `<sample>/fastqc/`, giving a before/after of what QC did to the reads.

- Runs in the **base image** (FastQC is already there) — no new container.
- Gated by `skip_fastqc` (default false, opt-out). `MARK_COMPLETE` gated on it.
- Per-sample only.

A per-sample MultiQC report was considered but rejected (not worth another container for two FastQC outputs) — recorded as the rejected alternative in ADR-0008.

## Testing
- `just test-nf` — 8/8 pass (`skip_fastqc=true` stub case included).
- `just test-stub` — publishes `<sample>/fastqc/decontaminated_fastqc/`; no `multiqc/`.
- `just test-config-all` — all profiles resolve.

No new container, so no container-tag caveat this time.

Branched off `main` after #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)