### PR TITLE
config(alpine): SLURM settings in-profile + persistent store_dir (supersedes #43)

### DIFF
--- a/conf/profiles/alpine.config
+++ b/conf/profiles/alpine.config
@@ -1,13 +1,25 @@
 /*
- * Alpine profile
+ * Alpine profile (CU Alpine, SLURM)
+ *
+ * SLURM executor settings live here in the repo rather than being injected via
+ * a generated override at dispatch time. Mirrors the sibling anvil SLURM
+ * profile. Alpine's scheduler rejects jobs without an explicit time limit, so
+ * process.time is required.
+ *
+ * store_dir points at a persistent project path (not /scratch, which is
+ * periodically purged) so the reference databases are downloaded once and
+ * reused across runs; the singularity bind mount matches.
  */
 
 profiles {
     alpine {
-        workDir = 'work'
-        params.store_dir = "/scratch/alpine/${USER}/curatedMetagenomicsNextflow/keep/store/"
+        process.executor  = 'slurm'
+        process.queueSize = 200
+        process.time      = '24h'
 
-        singularity.runOptions = "--bind /scratch/alpine/${USER}/curatedMetagenomicsNextflow/keep/store/:/keep/store/"
-        // process.executor = 'slurm'
+        workDir = 'work'
+        params.store_dir = '/projects/seda0001_amc/cmgd/store'
+
+        singularity.runOptions = "--bind /projects/seda0001_amc/cmgd/store:/keep/store/"
     }
 }


### PR DESCRIPTION
Re-applies the still-valid intent of the stale draft #43 to the **current** profile location.

## Why a fresh PR instead of #43
#43 was opened May 1 against the pre-refactor layout (the `alpine` block lived in `nextflow.config`). Since then profiles moved to `conf/profiles/*.config`, so #43 conflicts and edits a block that no longer exists there. It also bumped `manifest.version` 1.4.0 → 1.5.0, now obsolete (`main` is 1.6.0). The two fixes it identified, however, were never applied to the new `conf/profiles/alpine.config`.

## Changes (conf/profiles/alpine.config)
- **SLURM settings in-repo** instead of injected at dispatch: `process.executor = 'slurm'`, `process.queueSize = 200`, and an explicit `process.time = '24h'` (Alpine's scheduler rejects jobs without a time limit). Mirrors the sibling `anvil` profile.
- **Persistent `store_dir`**: `/projects/seda0001_amc/cmgd/store` (confirmed current) instead of the periodically-purged `/scratch/alpine/...` path, so reference DBs download once and are reused; the singularity bind mount is updated to match.

No version bump.

## Testing
- `nextflow config -profile alpine` resolves with the expected executor/queueSize/time/store_dir.
- `-profile alpine,gcs` composes cleanly.
- `just test-config-all` — all profiles resolve.

Once merged I'll close #43 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)