### PR TITLE
chore: bump workflow version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Results will be organized by sample in the `publish_dir` directory.
 ```
 <publish_base_dir>/
 ├── cmgd_nextflow/
-│   ├── 1.6.0/
+│   ├── 2.0.0/
 │   │   ├── sample1/
 │   │   │   ├── manifest.json     (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE
@@ -263,7 +263,7 @@ Results will be organized by sample in the `publish_dir` directory.
 ```
 <publish_base_dir>/
 ├── cmgd_nextflow/
-│   ├── 1.6.0/
+│   ├── 2.0.0/
 │   │   ├── sample1/
 │   │   │   ├── manifest.json   (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE

--- a/nextflow.config
+++ b/nextflow.config
@@ -190,7 +190,7 @@ manifest {
     homePage = 'https://github.com/seandavi/curatedmetagenomicsnextflow'
     mainScript = 'main.nf'
     name = 'cmgd_nextflow'
-    version = '1.6.0'
+    version = '2.0.0'
 }
 
 report {


### PR DESCRIPTION
Bumps `manifest.version` 1.6.0 → **2.0.0** ahead of the full-scale run.

## Why 2.0.0 (major)
This cycle's changes were technically *additive* — new opt-out per-sample outputs (GTDB, Kraken2/Bracken, resistome, manifest, post-decontamination FastQC) with no existing output renamed or removed, so the output contract held. But the **default run changed materially**: it now pulls new containers and a ~16 GB Kraken PlusPF DB + CARD, and needs more RAM/runtime. An existing 1.x deployment re-running the same command gets a substantially heavier run — the kind of operationally-breaking change a major version should flag.

It also cleanly **namespaces the output tree**: the version is embedded in the publish path (`<base>/<workflow>/<version>/<sample>/…`), so 2.0.0 separates this run's expanded outputs from the prior 1.x results.

## Changes
- `nextflow.config`: `manifest.version` → `2.0.0`.
- `README.md`: output-tree examples updated to `2.0.0/`.

## Verified
- `nextflow config` resolves `version = '2.0.0'`.
- Stub run publishes under `cmgd_nextflow/2.0.0/`.
- No remaining `1.6.0`/`1.7.0` references in `nextflow.config`/`README.md`.

(Branch is cosmetically named `…v1.7.0` from a mid-flight change of heart; it's deleted on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)