### PR TITLE
docker: sync Dockerfile with the metaphlan4.2.2 image recipe

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,10 @@ WORKDIR /installed
 RUN wget https://github.com/BenLangmead/bowtie2/releases/download/v2.5.4/bowtie2-2.5.4-linux-x86_64.zip && unzip bowtie2-2.5.4-linux-x86_64.zip && chmod +x bowtie2-2.5.4-linux-x86_64/bowtie2*
 ENV PATH=$PATH:/installed/bowtie2-2.5.4-linux-x86_64/
 
-## install humann, metaphlan, and awscli
-RUN pip install humann --no-binary :all: 
-RUN pip install metaphlan==4.2.2 
+## install metaphlan
+RUN pip install metaphlan==4.2.2
+
+## install awscli
 RUN pip install awscli
 
 ## install SAMtools-1.21
@@ -48,15 +49,24 @@ RUN curl -L https://github.com/lh3/minimap2/releases/download/v2.30/minimap2-2.3
 ENV PATH=$PATH:/installed/minimap2-2.30_x64-linux/
 
 ## install kneaddata
-RUN pip install kneaddata --install-option='--bypass-dependencies-install'
+RUN pip install kneaddata==0.12.3 --install-option='--bypass-dependencies-install'
 
 ## install trimmomatic for kneaddata
 RUN wget http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.39.zip && unzip Trimmomatic-0.39.zip
 
+## install humann, metaphlan, and awscli
+RUN pip install humann==4.0.0a1
+
+WORKDIR /installed
+
 ## display versions
-RUN fastq-dump --version
-RUN metaphlan --version
-RUN humann --version
+RUN echo 'VERSIONS' > versions.txt
+RUN echo 'fastq-dump' >> versions.txt
+RUN fastq-dump --version >> versions.txt
+RUN echo 'metaphlan' >> versions.txt
+RUN metaphlan --version >> versions.txt
+RUN echo 'humann' >> versions.txt
+RUN humann --version >> versions.txt
 
 ## root directory for databases
 ENV mpa_dir=/usr/local/miniconda3/lib/python3.7/site-packages/metaphlan


### PR DESCRIPTION
`main`'s `docker/Dockerfile` was out of date relative to the container the pipeline actually runs. `conf/base.config` pins `docker://seandavi/curatedmetagenomics:metaphlan4.2.2`, but the recipe that built that image lived **only** on the unmerged `metaphlan4.2.2` branch (commit `1262636`, Mar 2026) and was never brought into `main`.

This ports that exact `docker/Dockerfile` onto `main` so the repo reflects the image we've been using:

- pin `metaphlan==4.2.2`, `kneaddata==0.12.3`, `humann==4.0.0a1`
- split the awscli install out
- write a `versions.txt` into the image

**No pipeline behavior change** — it only brings the build recipe in line with the already-deployed image (confirmed by Sean that we've been working with this implicitly).

## After merge
The `metaphlan4.2.2` branch (local + remote) will be retired, since its sole content now lives on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)