### PR TITLE
feat(telemetry): upload .command.out (stdout) per task

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -221,8 +221,11 @@ weblog {
  *
  * afterScript runs on the host (outside the container) immediately after
  * each task finishes, success or failure. We upload .command.sh (the
- * rendered script) and .command.err (stderr) to the telemetry server.
- * Both curls use || true so a network hiccup never fails the task.
+ * rendered script), .command.out (stdout) and .command.err (stderr) to the
+ * telemetry server. Processes that report on stdout (e.g. kraken2) leave
+ * .command.err empty, so without the .command.out upload those tasks look
+ * like they produced no logs at all.
+ * All curls use || true so a network hiccup never fails the task.
  */
 process {
     afterScript = """
@@ -233,6 +236,12 @@ process {
             -F "task_hash=\$_hash" \\
             -F "log_type=command_sh" \\
             -F "content=@.command.sh" \\
+            "${params.api_url}/task-logs" || true
+          curl -sf -X POST \\
+            -F "run_name=${params.run_name}" \\
+            -F "task_hash=\$_hash" \\
+            -F "log_type=command_out" \\
+            -F "content=@.command.out" \\
             "${params.api_url}/task-logs" || true
           curl -sf -X POST \\
             -F "run_name=${params.run_name}" \\


### PR DESCRIPTION
## Summary
kraken2 (and other stdout-reporting processes) leave `.command.err` empty, so those tasks appeared to have **no logs** in the telemetry server. The per-task `afterScript` only uploaded `.command.sh` and `.command.err`.

This adds a third curl uploading `.command.out` as `log_type=command_out`.

## Requires
Telemetry server must accept `log_type=command_out` first → seandavi/nextflow_telemetry#100 (raises the per-file cap to 5 MB too, since kraken2 stdout can be large). Deploy that before this reaches a running cluster, else the new curl 422s (harmless — guarded by `|| true` — but no log stored).

## Rollout note
This is on `main`. Production runs pin tag `2.0.0`, so a new tag + workflow revision bump is needed for it to take effect on the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)