### PR TITLE
fix(rarefy_fastq): set cpus + escalating memory

### DIFF
--- a/modules/processes/rarefaction.nf
+++ b/modules/processes/rarefaction.nf
@@ -12,6 +12,14 @@ process rarefy_fastq {
 
     tag "${meta.sample}"
 
+    // Set in-body (like the sibling qc processes) rather than via a
+    // conf/base.config withName, so the directive holds even if this process
+    // is later imported under an alias. seqtk sample is light; the headroom is
+    // for large inputs. Memory escalates on retry (Alpine caps time at 24h, so
+    // no time escalation — memory only).
+    cpus 2
+    memory { 8.GB * task.attempt }
+
     input:
     val meta
     path fastq


### PR DESCRIPTION
## Summary
`rarefy_fastq` was the only pipeline process with **no resource directive** — just `label 'qc'`. It ran at the cluster default memory (~3.75 G on Alpine). This sets explicit resources in-body, matching the sibling qc process `fastqc`.

```groovy
cpus 2
memory { 8.GB * task.attempt }
```

- **Memory escalates on retry** (`× task.attempt`); seqtk `sample` is light, the 8 G base is headroom for large inputs.
- **No time directive** — Alpine caps wall time at 24 h, so memory-only escalation (per maintainer).
- **In-body, not a `conf/base.config` withName** — consistent with the other tool/qc processes, and survives if this process is later aliased (the same rationale documented in `kraken.nf`).

## Audit of the others (no change needed)
| process | memory | escalates |
|---|---|---|
| kraken2 | 32 GB in-body | ✓ |
| bracken | 4 GB in-body | ✓ |
| resistome | 16 GB in-body | ✓ |
| fastqc | 4 GB in-body | ✓ |
| kraken_db / card_db | 4 GB / 2 GB static | downloads (download_retry, maxRetries 4) |

So `rarefy_fastq` was the lone gap.

## Rollout
Production pins a tag; needs a new tag + workflow revision bump to take effect (same as prior changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)