### PR TITLE
feat(config): errorStrategy finish, GCS profile split, manifest 2.0.4

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -15,11 +15,13 @@ process {
     container = 'docker://seandavi/curatedmetagenomics:metaphlan4.2.2'
 
     /*
-     * Conservative default retry policy:
-     * - retry common scheduler kill / OOM exit codes
-     * - terminate on other failures unless a profile overrides behavior
+     * Retry policy (ADR-0010):
+     * - retry the OOM / scheduler-kill exit family (137..140) with more memory
+     * - on anything else use 'finish', NOT 'terminate', so a single
+     *   unrecoverable task lets the already-running siblings complete instead of
+     *   aborting the whole batch (one bad sample no longer fails the run).
      */
-    errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'terminate' }
+    errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'finish' }
     maxRetries = 3
 
     /*

--- a/conf/profiles/gcs.config
+++ b/conf/profiles/gcs.config
@@ -1,14 +1,25 @@
 /*
- * GCS storage profile
+ * GCS storage profiles (split — see ADR-0011)
  *
- * Routes pipeline outputs and Nextflow work files to Google Cloud Storage.
- * Compose with a compute profile rather than using alone:
+ * `gcs`     — publish pipeline OUTPUTS to GCS, leaving workDir wherever the
+ *             compute profile put it (e.g. local scratch on HPC). Safe to
+ *             compose with an HPC compute profile:
  *
- *   -profile google,gcs     # Google Batch compute + GCS storage
- *   -profile alpine,gcs     # HPC compute + GCS output
+ *               -profile alpine,gcs    # HPC compute, local workDir, GCS output
  *
- * publish_mode is set to 'copy' because symbolic links are not meaningful
- * across cloud storage boundaries.
+ *             The Nextflow driver does the publishDir copy to gs://, so it needs
+ *             GOOGLE_APPLICATION_CREDENTIALS (the submit template exports it) and
+ *             google.project set (below).
+ *
+ * `gcswork` — additionally route the Nextflow WORK directory to GCS. Only
+ *             sensible for cloud compute (Google Batch), where tasks read/write
+ *             work natively from gs://. Do NOT use on the SLURM executor unless
+ *             a GCS-backed work filesystem (fusion/gcsfuse) is configured:
+ *
+ *               -profile google,gcs,gcswork    # cloud compute + GCS work + output
+ *
+ * publish_mode is 'copy' because symlinks are not meaningful across cloud
+ * storage boundaries.
  */
 
 profiles {
@@ -16,8 +27,10 @@ profiles {
         params.publish_base_dir = "gs://cmgd-data/results/cMDv${params.cmgd_version}"
         params.publish_mode     = 'copy'
 
-        workDir = 'gs://cmgd-data/work'
+        google.project = 'curatedmetagenomicdata'
+    }
 
-        google.project = 'omicidx-338300'
+    gcswork {
+        workDir = 'gs://cmgd-data/work'
     }
 }

--- a/docs/adr/0009-retry-and-failure-handling-policy.md
+++ b/docs/adr/0009-retry-and-failure-handling-policy.md
@@ -1,6 +1,6 @@
 # 0009. Retry and failure-handling policy
 
-- **Status:** Accepted
+- **Status:** Accepted (error-action choice superseded by [0010](0010-error-strategy-finish.md); retry policy still in force)
 - **Date:** 2026-06-04
 - **Deciders:** Sean Davis
 

--- a/docs/adr/0010-error-strategy-finish.md
+++ b/docs/adr/0010-error-strategy-finish.md
@@ -1,0 +1,54 @@
+# 0010. Use errorStrategy 'finish' instead of 'terminate'
+
+- **Status:** Accepted (supersedes the error-action choice in [0009](0009-retry-and-failure-handling-policy.md))
+- **Date:** 2026-06-04
+- **Deciders:** Sean Davis
+
+## Context
+
+[0009](0009-retry-and-failure-handling-policy.md) set the retry policy and used
+`'terminate'` for non-retryable failures, while explicitly flagging
+`'finish'` as deferred-not-rejected. Production experience settled it: with
+`executor = 'slurm'` and per-sample batching, a single unrecoverable task (e.g.
+the RGI image that failed to pull) made Nextflow **terminate the whole run** —
+cancelling every in-flight sibling task, which then surfaced as a wave of
+`ABORTED` tasks and failed/dead-lettered jobs for samples that had nothing wrong
+with them. One bad sample failed the entire batch.
+
+## Decision
+
+We will use **`errorStrategy = 'finish'`** for the non-retryable branch (the
+retry-the-137..140-kill-family behaviour from 0009 is unchanged):
+
+```groovy
+errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'finish' }
+```
+
+`'finish'` lets tasks already running complete and stops launching new ones,
+then ends the run with a non-zero status — instead of `'terminate'`, which kills
+running tasks immediately.
+
+## Alternatives considered
+
+- **`'terminate'`** (the 0009 status quo) — rejected: one unrecoverable task
+  wastes all concurrent work in the batch and inflates the failure/DLQ counts
+  with collateral, obscuring the real cause.
+- **`'ignore'`** — rejected: it would let the run report success while silently
+  dropping failed samples. We want the run to end non-zero so the orchestrator
+  sweeps the genuinely-incomplete jobs, just without nuking healthy siblings.
+
+## Consequences
+
+- A single bad sample no longer aborts the batch; sibling tasks finish and their
+  outputs/telemetry are preserved.
+- Runs with a failed task still end non-zero, so the telemetry sweep
+  (close-run → retry/DLQ) still routes the incomplete jobs correctly — now
+  scoped to the actually-failed samples rather than the whole batch.
+- Slightly longer wind-down on failure (running tasks drain rather than being
+  killed). Accepted — the wasted-work cost of `terminate` was larger.
+
+## References
+
+- `conf/base.config` (`errorStrategy`).
+- Supersedes the error-action choice in [0009](0009-retry-and-failure-handling-policy.md).
+- Trigger case: RGI container tag fix (manifest unknown → terminate cascade).

--- a/docs/adr/0011-gcs-storage-profile-split.md
+++ b/docs/adr/0011-gcs-storage-profile-split.md
@@ -1,0 +1,57 @@
+# 0011. Split the GCS storage profile (publish vs work)
+
+- **Status:** Accepted
+- **Date:** 2026-06-04
+- **Deciders:** Sean Davis
+
+## Context
+
+The `gcs` profile bundled two independent choices: publishing pipeline
+**outputs** to GCS *and* routing the Nextflow **work** directory to GCS. That
+bundling made it unusable on HPC: composing `-profile alpine,gcs` to get
+durable GCS output also forced `workDir = gs://cmgd-data/work`, which the SLURM
+executor cannot use without a GCS-backed work filesystem (fusion/gcsfuse). The
+practical effect was that nobody enabled `gcs` on Alpine, so outputs went to the
+default `${launchDir}/results` on scratch — and were deleted with the work dir
+at the end of each job. Nothing durable was produced, and the per-task
+`.command*` files (a useful debugging/progress view) were lost.
+
+The two concerns are separable: GCS *publish* only needs the driver to copy
+results to `gs://` (it has `GOOGLE_APPLICATION_CREDENTIALS`); GCS *workDir* only
+makes sense for cloud compute that reads/writes work natively from `gs://`.
+
+## Decision
+
+We will split the profile in two:
+
+- **`gcs`** — publish outputs to GCS (`publish_base_dir = gs://…`,
+  `publish_mode = 'copy'`, `google.project`). No `workDir` override. Safe to
+  compose with HPC: `-profile alpine,gcs` = local scratch workDir, GCS output.
+- **`gcswork`** — only sets `workDir = gs://cmgd-data/work`. For cloud compute:
+  `-profile google,gcs,gcswork`.
+
+HPC production uses `-profile alpine,gcs`.
+
+## Alternatives considered
+
+- **Keep the combined profile** — rejected: couples output durability to a
+  cloud workDir that doesn't work on SLURM, so it stayed off and outputs were
+  ephemeral.
+- **Set GCS workDir on HPC via gcsfuse/fusion** — deferred: more moving parts on
+  the compute nodes than warranted; local scratch workDir is fine, only the
+  results need to persist.
+
+## Consequences
+
+- `-profile alpine,gcs` now publishes durable outputs (including each process's
+  `.command*`) to `gs://cmgd-data/results/cMDv<cmgd_version>/<name>/<version>/…`
+  while keeping a fast local scratch workDir.
+- Validation gating: the driver's publishDir copy to `gs://` depends on
+  Nextflow's GCS filesystem support + credentials being present in the job — the
+  first real `alpine,gcs` run is the true test (cf. ADR-0007's note).
+- Cloud-compute runs must now add `gcswork` explicitly to get GCS work staging.
+
+## References
+
+- `conf/profiles/gcs.config`.
+- Output path derivation: `nextflow.config` `publish_base_dir`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,4 +56,6 @@ other. This preserves the historical record rather than rewriting it.
 | [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted |
 | [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted |
 | [0008](0008-per-sample-qc-reporting.md) | Per-sample post-decontamination FastQC | Accepted |
-| [0009](0009-retry-and-failure-handling-policy.md) | Retry and failure-handling policy | Accepted |
+| [0009](0009-retry-and-failure-handling-policy.md) | Retry and failure-handling policy | Accepted (error-action superseded by 0010) |
+| [0010](0010-error-strategy-finish.md) | Use errorStrategy 'finish' instead of 'terminate' | Accepted |
+| [0011](0011-gcs-storage-profile-split.md) | Split the GCS storage profile (publish vs work) | Accepted |

--- a/nextflow.config
+++ b/nextflow.config
@@ -190,7 +190,7 @@ manifest {
     homePage = 'https://github.com/seandavi/curatedmetagenomicsnextflow'
     mainScript = 'main.nf'
     name = 'cmgd_nextflow'
-    version = '2.0.0'
+    version = '2.0.4'
 }
 
 report {


### PR DESCRIPTION
Three approved cmgd config changes + ADRs:

- **errorStrategy `finish`** (was `terminate`) — one unrecoverable task no longer aborts the whole batch; siblings finish. ADR-0010 (supersedes 0009's action).
- **GCS profile split** — `gcs` = publish outputs to GCS only (HPC-safe: `-profile alpine,gcs`, local scratch workDir); new `gcswork` carries the GCS workDir for cloud compute. Also fixes `google.project` → `curatedmetagenomicdata`. ADR-0011.
- **manifest.version 2.0.0 → 2.0.4** so published paths + telemetry match the git tag.

Enabling `-profile alpine,gcs` (client config) publishes durable outputs incl. each process's `.command*` to `gs://cmgd-data/results/cMDv4/cmgd_nextflow/2.0.4/<sample>/<step>` — a persistent progress/debug view.

First `alpine,gcs` run validates the publishDir→gs:// path (creds/plugin) per ADR-0011.
🤖 Generated with [Claude Code](https://claude.com/claude-code)