### PR TITLE
fix(errorStrategy): isolate per-sample failures instead of poisoning the batch (2.0.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The version is the git tag, the `manifest.version` in `nextflow.config`, and the
 workflow revision the orchestrator dispatches — keep all three in lockstep.
 
+## [2.0.7] - 2026-07-02
+
+### Changed
+- **Failure isolation: a single bad sample no longer poisons its batch.** The
+  default `errorStrategy` for per-sample compute processes now ends in `ignore`
+  instead of `finish`. `finish` halted submission of NEW tasks on any non-OOM
+  failure, so when one sample's early `fasterq_dump` failed (e.g. exit 3 on a
+  bad/unavailable SRA accession) the whole batch's downstream tasks never
+  launched — none of the batch-mates reached `MARK_COMPLETE` and all up-to-25
+  samples were dead-lettered. Live incident: 4 bad downloads took down 56
+  samples, 52 of them healthy collateral. New policy:
+  `{ (task.exitStatus in 137..140 && task.attempt <= 4) ? 'retry' : (task.attempt <= 2 ? 'retry' : 'ignore') }`
+  — retry the OOM/scheduler-kill family up to 4× (with escalating memory), retry
+  any other failure once, then `ignore` (drop just that sample).
+- Applied the same retry-then-`ignore` shape to the `google` (Google Batch)
+  profile, which previously used `terminate` — strictly worse than `finish`. The
+  exit-14 spot/preemption retry is preserved.
+
+### Fixed
+- **Shared/critical processes stay fail-hard.** Added `withLabel` fail-hard
+  overrides so failure isolation never silently ruins a run:
+  - `db_setup` — every reference/database process in
+    `modules/processes/databases.nf` (install_metaphlan_db, chocophlan_db,
+    utility_mapping_db, uniref_db, sgb_to_gtdb_db, kraken_db, card_db,
+    kneaddata_human_database, kneaddata_mouse_database). A broken shared DB must
+    stop the run loudly, not silently ruin every sample.
+  - `finalize` — MARK_COMPLETE (completion sentinel) and sample_manifest
+    (publish/manifest). `ignore`ing these would mark a sample complete without
+    outputs or drop its manifest.
+  These retry transient failures, then `finish` (never `ignore`).
+
+### Notes
+- Profile resolution: the production daemon runs `-profile alpine,gcs`. Neither
+  `alpine` nor `gcs` overrides `errorStrategy`, so the effective strategy for
+  that run is the `conf/base.config` default — which is exactly what this change
+  fixes. The `google` profile's `terminate` override only activates under
+  `-profile google` and was fixed for completeness.
+
 ## [2.0.6] - 2026-06-04
 
 ### Fixed
@@ -89,6 +127,7 @@ Baseline of the 2.x line. Core metagenomic pipeline, with decisions recorded in
 - HUMAnN functional profiling is deferred pending MetaPhlAn/HUMAnN version
   alignment (ADR-0002).
 
+[2.0.7]: https://github.com/seandavi/curatedMetagenomicsNextflow/compare/2.0.6...2.0.7
 [2.0.6]: https://github.com/seandavi/curatedMetagenomicsNextflow/compare/2.0.5...2.0.6
 [2.0.5]: https://github.com/seandavi/curatedMetagenomicsNextflow/compare/2.0.4...2.0.5
 [2.0.4]: https://github.com/seandavi/curatedMetagenomicsNextflow/compare/2.0.3...2.0.4

--- a/conf/base.config
+++ b/conf/base.config
@@ -15,20 +15,70 @@ process {
     container = 'docker://seandavi/curatedmetagenomics:metaphlan4.2.2'
 
     /*
-     * Retry policy (ADR-0010):
-     * - retry the OOM / scheduler-kill exit family (137..140) with more memory
-     * - on anything else use 'finish', NOT 'terminate', so a single
-     *   unrecoverable task lets the already-running siblings complete instead of
-     *   aborting the whole batch (one bad sample no longer fails the run).
+     * Retry policy — failure ISOLATION (ADR-0010, revised 2.0.7):
+     *
+     * The pipeline dispatches many samples per Nextflow run (batches of up to
+     * 25). Each sample flows through its own chain of per-sample compute tasks.
+     * A terminal 'finish' (or worse, 'terminate') on ANY per-sample task poisons
+     * the whole batch: Nextflow stops submitting NEW tasks, so the surviving
+     * batch-mates never reach their MARK_COMPLETE sentinel and the orchestrator
+     * dead-letters every sample in the batch. Live incident: 4 bad SRA downloads
+     * (fasterq_dump exit 3) took down 56 samples, 52 of them perfectly healthy.
+     *
+     * The default policy below therefore ends in 'ignore' rather than 'finish':
+     * a per-sample task that cannot be recovered is DROPPED (that one sample is
+     * lost) but its batch-mates keep flowing to completion.
+     *
+     *   - OOM / scheduler-kill family (137..140): retry up to 4 times. Baseline
+     *     memory is a function of task.attempt for these processes, so each
+     *     retry requests proportionally more memory.
+     *   - any other failure (bad accession, transient tool/network error):
+     *     retry once (attempt <= 2), then 'ignore' — drop just this sample.
+     *
+     * Processes that are SHARED across the whole batch (reference/database
+     * downloads) or that FINALIZE a sample (MARK_COMPLETE sentinel, publish/
+     * manifest) must NEVER be 'ignore'd — a broken shared DB or a failed publish
+     * has to stop the run loudly, not silently ruin every sample. Those are
+     * overridden to fail-hard below via withLabel selectors.
      */
-    errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'finish' }
-    maxRetries = 3
+    errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 4) ? 'retry' : (task.attempt <= 2 ? 'retry' : 'ignore') }
+    maxRetries = 4
 
     /*
      * Labels are intentionally semantic. They communicate process class and
      * drive retry behavior, while exact baseline resources remain process-
      * specific below so the original sizing contract stays intact.
      */
+
+    /*
+     * Fail-hard overrides — these categories must NEVER 'ignore'.
+     *
+     * db_setup: every reference/database process in
+     *   modules/processes/databases.nf (install_metaphlan_db, chocophlan_db,
+     *   utility_mapping_db, uniref_db, sgb_to_gtdb_db, kraken_db, card_db,
+     *   kneaddata_human_database, kneaddata_mouse_database). These are shared
+     *   across the whole batch via storeDir. A broken shared DB must stop the
+     *   run loudly rather than silently ruin every sample, so retry transient
+     *   failures (with growing memory for the OOM family) and then 'finish'.
+     *
+     * finalize: MARK_COMPLETE (the per-sample completion sentinel) and
+     *   sample_manifest (the publish/manifest step) — both in
+     *   modules/processes/{finalize,manifest}.nf. Silently 'ignore'ing these
+     *   would mark a sample complete without its outputs, or drop the manifest,
+     *   corrupting the published contract. Retry transient failures, then
+     *   'finish'.
+     *
+     * Both selectors must be listed AFTER the process-scope default above so
+     * they win for their labelled processes (Nextflow applies withLabel on top
+     * of the process-scope errorStrategy).
+     */
+    withLabel: 'db_setup' {
+        errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 4) ? 'retry' : (task.attempt <= 2 ? 'retry' : 'finish') }
+    }
+
+    withLabel: 'finalize' {
+        errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 4) ? 'retry' : (task.attempt <= 2 ? 'retry' : 'finish') }
+    }
 
     withLabel: 'download_retry' {
         maxRetries = 4

--- a/conf/profiles/google.config
+++ b/conf/profiles/google.config
@@ -10,8 +10,20 @@
 profiles {
     google {
         process.executor = 'google-batch'
-        process.errorStrategy = { task.exitStatus == 14 || (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'terminate' }
-        process.maxRetries = 3
+        /*
+         * Failure isolation on Google Batch (see conf/base.config for the full
+         * rationale). This overrides the process-scope default with the SAME
+         * retry-then-ignore shape so a single bad per-sample task drops only
+         * that sample instead of terminating the whole batch — the old
+         * 'terminate' was strictly worse than base.config's 'finish'.
+         *
+         * exit 14 is Google Batch spot/preemption; keep retrying it. The
+         * withLabel fail-hard overrides in base.config (db_setup, finalize)
+         * still apply on top of this process-scope setting, so shared DBs and
+         * the completion/publish sentinels stay fail-hard here too.
+         */
+        process.errorStrategy = { (task.exitStatus == 14 || (task.exitStatus in 137..140 && task.attempt <= 4)) ? 'retry' : (task.attempt <= 2 ? 'retry' : 'ignore') }
+        process.maxRetries = 4
 
         google.batch.bootDiskSize = '100.GB'
         google.batch.spot = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -190,7 +190,7 @@ manifest {
     homePage = 'https://github.com/seandavi/curatedmetagenomicsnextflow'
     mainScript = 'main.nf'
     name = 'cmgd_nextflow'
-    version = '2.0.6'
+    version = '2.0.7'
 }
 
 report {


### PR DESCRIPTION
## Problem — one bad sample dead-letters the whole batch

The pipeline dispatches up to **25 samples per Nextflow run**. Each sample flows through its own chain of per-sample compute tasks (`fasterq_dump` → `kneaddata` → profiling → `MARK_COMPLETE`).

The default `errorStrategy` in `conf/base.config` was:

```groovy
errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 3) ? 'retry' : 'finish' }
```

`'finish'` halts submission of **new** tasks on any non-OOM failure. So when one sample's early `fasterq_dump` fails (e.g. exit 3 — a bad/unavailable SRA accession), the whole batch's downstream tasks never launch: none of the batch-mates reach the `MARK_COMPLETE` sentinel, so the orchestrator dead-letters **every** sample in the batch.

**Live incident:** 4 bad downloads took down 56 samples — 52 of them perfectly healthy collateral. The `google` profile used `'terminate'`, which is strictly worse (aborts in-flight tasks too).

## Fix — failure isolation: retry-then-`ignore` for per-sample work, fail-hard for shared/critical

### Default (per-sample compute) — ends in `ignore`
```groovy
errorStrategy = { (task.exitStatus in 137..140 && task.attempt <= 4) ? 'retry' : (task.attempt <= 2 ? 'retry' : 'ignore') }
maxRetries = 4
```
- OOM / scheduler-kill family (`137..140`): retry up to 4× (baseline memory is `{ N.GB * task.attempt }` for these processes, so each retry asks for more memory).
- Any other failure (bad accession, transient tool/network error): retry **once**, then `ignore` — drop **just that sample**. Its batch-mates keep flowing to completion.

### Fail-hard overrides — must NEVER `ignore`
Added `withLabel` selectors (the repo already labels these process classes, so label selectors are cleaner than enumerating `withName`):

| Label | Processes | Why fail-hard |
|-------|-----------|---------------|
| `db_setup` | all 9 reference/DB processes in `modules/processes/databases.nf` — install_metaphlan_db, chocophlan_db, utility_mapping_db, uniref_db, sgb_to_gtdb_db, kraken_db, card_db, kneaddata_human_database, kneaddata_mouse_database | shared across the whole batch via `storeDir`; a broken shared DB must stop the run loudly, not silently ruin every sample |
| `finalize` | MARK_COMPLETE (`finalize.nf`) + sample_manifest (`manifest.nf`) | `ignore`ing these would mark a sample complete without outputs, or drop its manifest — corrupting the published contract |

Both override to retry transient failures then `'finish'` (never `'ignore'`).

### `google` profile
Rewritten from `'terminate'` to the same retry-then-`ignore` shape (exit-14 spot/preemption retry preserved). The `base.config` `withLabel` fail-hard overrides still apply on top of the profile's process-scope `errorStrategy`, because selector-scoped settings take precedence over the generic process scope.

## Profile-resolution reasoning (critical)

The production daemon runs **`-profile alpine,gcs`**. Resolution:

- `nextflow.config` `includeConfig`s every profile file unconditionally, but the `profiles { ... }` blocks inside them only **activate** when named in `-profile`.
- For `alpine,gcs`, only the `alpine` and `gcs` blocks activate. **Neither overrides `errorStrategy`** (`alpine` sets executor/time/store_dir; `gcs` sets publish/`google.project`). So the effective strategy for the production run is the `conf/base.config` default — exactly what this PR fixes.
- The `google` profile's `errorStrategy` (formerly `'terminate'`) only activates under `-profile google`; it is **not** in the `alpine,gcs` chain. Fixed anyway for correctness.

Confirmed by `grep -rn errorStrategy conf/ nextflow.config`: only `base.config`, `google.config`, and `unitn.config` declare one; the latter two are profile-gated.

## Validation

`nextflow config` on the full `nextflow.config` fails to parse in Nextflow 26 due to a **pre-existing** top-level `import groovy.json.JsonOutput` (confirmed identical failure on the unmodified 2.0.6 tree; the `nextflow run` path tolerates it). Validated instead by resolving the edited config files through Nextflow's real engine via an isolated wrapper that `includeConfig`s them:

```
nextflow config -profile alpine,gcs   →
  process.errorStrategy            ... : 'ignore'   (per-sample isolation) ✓
  withLabel:db_setup errorStrategy ... : 'finish'   (fail-hard)            ✓
  withLabel:finalize errorStrategy ... : 'finish'   (fail-hard)            ✓

nextflow config -profile google,gcs   →
  process.errorStrategy (exit-14 retry kept) ... : 'ignore'  ✓
  withLabel:db_setup / finalize              ... : 'finish'  ✓
```
Braces balanced in all edited files; closures parse and render as intended.

## Changes
- `conf/base.config` — default errorStrategy `finish` → `ignore`; add `withLabel: db_setup` and `withLabel: finalize` fail-hard overrides; `maxRetries` 3 → 4.
- `conf/profiles/google.config` — `terminate` → retry-then-`ignore` (exit-14 retry kept); `maxRetries` 3 → 4.
- `nextflow.config` — `manifest.version` 2.0.6 → 2.0.7.
- `CHANGELOG.md` — 2.0.7 entry.

**Not tagged / no GitHub release** — leaving that for human review before cutting 2.0.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)