### PR TITLE
feat: ENA-first read acquisition with SRA fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The version is the git tag, the `manifest.version` in `nextflow.config`, and the
 workflow revision the orchestrator dispatches — keep all three in lockstep.
 
+## [Unreleased]
+
+### Changed
+- **Read acquisition is now ENA-first with an SRA fallback** (`fasterq_dump`).
+  A class of SRA runs is archived without a QUALITY column, which makes
+  `fasterq-dump` exit 3 (`the input data is missing the QUALITY-column`);
+  under the retry/`ignore` policy those samples were dropped and dead-lettered.
+  All 14 DLQ jobs in the 2.0.7 batch failed this way, yet the reads are
+  published and downloadable as FASTQ from EBI/ENA. The process now resolves
+  `fastq_ftp` via the ENA `filereport` API, downloads over HTTPS and verifies
+  `fastq_md5`, and falls back per run to the original `curl .sra + fasterq-dump`
+  path when ENA serves no FASTQ (ingestion lag, submitted-only, controlled
+  access). No container change; the downstream output contract is unchanged.
+  Note: ENA FASTQ for quality-less runs carries synthetic qualities, so the
+  quality-trim step is a no-op for those samples (curation caveat). See ADR-0012.
+
 ## [2.0.7] - 2026-07-02
 
 ### Changed

--- a/docs/adr/0012-ena-first-read-acquisition.md
+++ b/docs/adr/0012-ena-first-read-acquisition.md
@@ -1,0 +1,79 @@
+# 0012. Acquire reads ENA-first with SRA fallback
+
+- **Status:** Accepted
+- **Date:** 2026-07-03
+- **Deciders:** Sean Davis
+
+## Context
+
+`fasterq_dump` acquires reads by `curl`-ing the `.sra` object from the AWS Open
+Data ODP mirror and running `fasterq-dump --split-files` on the local file.
+
+A class of SRA runs is archived **without a QUALITY column**. For those,
+`fasterq-dump` refuses to emit FASTQ and exits 3:
+
+```
+fasterq-dump err: the input data is missing the QUALITY-column
+```
+
+Under the current retry policy (ADR-0011) a non-OOM failure retries once and is
+then `ignore`d — so the sample is dropped, never reaches `MARK_COMPLETE`, and is
+dead-lettered by the orchestrator. In the 2.0.7 batch **all 14 dead-lettered
+jobs** failed this way (the download itself succeeds; the *dump* fails). The
+failure is 100% deterministic — it is a property of the archived object, not the
+transfer — so retrying, and equally prefetch-then-dump, cannot help.
+
+The underlying reads exist. Probing the EBI ENA `filereport` API showed FASTQ is
+published and downloadable for every one of these runs (and for a 50/50 sample
+of already-completed runs). ENA generates FASTQ even for quality-less runs, so
+fetching from ENA sidesteps the `fasterq-dump` wall entirely. ENA coverage is
+very high but not universal — brand-new runs (ingestion lag), submitted-only
+formats (BAM/CRAM without generated FASTQ), and controlled-access data may have
+no ENA FASTQ.
+
+## Decision
+
+We will acquire reads **ENA-first, per run accession**: resolve `fastq_ftp` via
+the ENA `filereport` API, download over HTTPS, and verify against the provided
+`fastq_md5`. When ENA serves no FASTQ for a run, fall back to the existing SRA
+path (`curl` the `.sra` + `fasterq-dump`). The downstream output contract
+(`out.fastq.gz` + lightweight QC) is unchanged.
+
+## Alternatives considered
+
+- **prefetch → fasterq-dump / nf-core `sratools` modules** — rejected: the
+  process already fetches the `.sra` then dumps locally, so it is already
+  prefetch-equivalent. The failure is in the dump step; a fetch-method change
+  fixes none of these runs.
+- **Switch ingestion to nf-core/fetchngs** — rejected for now: fetchngs is a
+  download-only pipeline that speaks none of our contracts (`md5(sorted SRRs)`
+  sample id, weblog telemetry, `MARK_COMPLETE`, `manifest.json`, publishDir
+  layout). Revisit as a *decoupled* ingestion stage only if download
+  volume/failure at 100k+ scale justifies a second orchestration surface.
+- **ENA-only (drop SRA)** — rejected: ENA coverage is not 100%; the SRA path
+  remains the backstop for the ENA-missing tail.
+
+## Consequences
+
+- Removes the QUALITY-column dead-letter class; the common path is also simpler
+  and faster (plain HTTPS download, no `.sra` intermediate or dump step).
+- Adds EBI/ENA as a runtime network dependency (transatlantic from US clusters);
+  per-run fallback to SRA covers ENA being unavailable.
+- ENA FASTQ for quality-less runs carries **synthetic** quality scores, so the
+  downstream quality-trim (kneaddata/trimmomatic) is effectively a no-op for
+  those samples. This is a curation consideration, not a pipeline bug — decide
+  separately whether such samples belong in the dataset.
+- ENA and `fasterq-dump` FASTQ are not byte-identical (read headers, paired-end
+  splitting); immaterial for taxonomic profiling but a reproducibility note if a
+  cohort mixes sources.
+- No new container: `curl`, `md5sum`, `cut`, `gunzip` are all in the base image.
+- The local-FASTQ input path (`local_fastqc`, cloud-bucket inputs) is out of
+  scope here and still needs its own design pass (identity keys, metadata,
+  user-supplied md5).
+
+## References
+
+- 2.0.7 dead-letter incident: 14/14 DLQ jobs = `fasterq-dump` exit 3,
+  `missing the QUALITY-column`; ENA `filereport` confirmed FASTQ live for all.
+- ENA filereport API: `https://www.ebi.ac.uk/ena/portal/api/filereport`
+- ADR-0011 (retry/ignore policy), `modules/processes/preprocessing.nf`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,3 +59,4 @@ other. This preserves the historical record rather than rewriting it.
 | [0009](0009-retry-and-failure-handling-policy.md) | Retry and failure-handling policy | Accepted (error-action superseded by 0010) |
 | [0010](0010-error-strategy-finish.md) | Use errorStrategy 'finish' instead of 'terminate' | Accepted |
 | [0011](0011-gcs-storage-profile-split.md) | Split the GCS storage profile (publish vs work) | Accepted |
+| [0012](0012-ena-first-read-acquisition.md) | Acquire reads ENA-first with SRA fallback | Accepted |

--- a/modules/processes/preprocessing.nf
+++ b/modules/processes/preprocessing.nf
@@ -45,17 +45,53 @@ process fasterq_dump {
     """
 
     echo "accessions: ${meta.accessions}" > sampleinfo.txt
-    echo "starting fasterq-dump"
+    # Read acquisition: ENA-first (published fastq), SRA fallback (curl .sra + fasterq-dump).
+    # ENA serves usable fastq even for runs whose SRA object lacks a QUALITY column
+    # (those make fasterq-dump exit 3); trying ENA first removes that whole failure class.
+    # Runs ENA does not serve (ingestion lag, submitted-only, controlled access) fall
+    # back to the original SRA path, so coverage is unchanged. See ADR-0012.
+    fetch_ena() {
+        acc=\$1
+        report=\$(curl -sf --max-time 60 "https://www.ebi.ac.uk/ena/portal/api/filereport?accession=\${acc}&result=read_run&fields=fastq_ftp,fastq_md5") || return 1
+        row=\$(printf '%s\\n' "\$report" | tail -n +2 | head -n1)
+        urls=\$(printf '%s' "\$row" | cut -f1)
+        md5s=\$(printf '%s' "\$row" | cut -f2)
+        [ -z "\$urls" ] && return 1
+        i=1
+        for u in \$(printf '%s' "\$urls" | tr ';' ' '); do
+            fn=\$(basename "\$u")
+            echo "  ENA \$fn"
+            curl -sf --max-time 3600 -o "\$fn" "https://\$u" || return 1
+            m=\$(printf '%s' "\$md5s" | cut -d';' -f\$i)
+            if [ -n "\$m" ]; then
+                echo "\$m  \$fn" | md5sum -c - || return 1
+            fi
+            i=\$((i + 1))
+        done
+        return 0
+    }
+
+    fetch_sra() {
+        acc=\$1
+        echo "  SRA \$acc"
+        curl -sf --max-time 3600 -o \$acc.sra https://sra-pub-run-odp.s3.amazonaws.com/sra/\$acc/\$acc || return 1
+        fasterq-dump --threads ${task.cpus} --skip-technical --force --split-files \$acc.sra
+    }
+
+    echo "starting read acquisition (ENA-first, SRA fallback)"
     for accession in ${meta.accessions.join(" ")}; do
-        echo "downloading \$accession"
-        curl -o \$accession.sra https://sra-pub-run-odp.s3.amazonaws.com/sra/\$accession/\$accession
-        fasterq-dump --threads ${task.cpus} \
-            --skip-technical \
-            --force \
-            --split-files \$accession.sra
+        echo "acquiring \$accession"
+        if ! fetch_ena \$accession; then
+            echo "  ENA unavailable for \$accession; falling back to SRA"
+            fetch_sra \$accession || { echo "ERROR: ENA and SRA both failed for \$accession"; exit 3; }
+        fi
     done
+
+    # ENA delivers *.fastq.gz; fasterq-dump delivers *.fastq. Unify to *.fastq.
+    for f in *.fastq.gz; do [ -e "\$f" ] && gunzip -f "\$f"; done
+
     ls -ld
-    echo "fasterq-dump done"
+    echo "read acquisition done"
     wc -l *.fastq > fastq_line_count.txt
 
     echo "combining fastq files and gzipping"


### PR DESCRIPTION
## What
`fasterq_dump` now acquires reads **ENA-first, per run accession** — resolves `fastq_ftp` via the ENA `filereport` API, downloads over HTTPS with `fastq_md5` verification — and **falls back per-run to the original `curl .sra` + `fasterq-dump`** when ENA serves no fastq.

## Why
A class of SRA runs is archived **without a QUALITY column**, making `fasterq-dump` exit 3 (`the input data is missing the QUALITY-column`). Under the retry/`ignore` policy those samples are dropped and dead-lettered. **All 14 DLQ jobs in the 2.0.7 batch failed this way** — yet the reads are published/downloadable as fastq from EBI/ENA. The download already succeeds today; the failure is in the *dump* step, so prefetch / nf-core `sratools` modules would fail identically. The SRA fallback preserves coverage for the ENA-missing tail.

## Scope
- Only `fasterq_dump`. Local-fastq / cloud-bucket path (`local_fastqc`) intentionally **out of scope** (needs its own design pass: identity keys, metadata, md5).
- No container change. **Not a version bump** — orchestrator re-points the revision to the merged hash (ADR-0004).

## Verification
- ✅ Stub-run compiles/passes on Nextflow 24.04.4 (`fasterq_dump 3/3 ✔`).
- ⚠️ `-stub-run` uses the `stub:` block; ENA bash logic **not** exercised here. Plan: requeue the 14 DLQ accessions (all live at ENA) against the new revision and watch.

## Caveats (ADR-0012)
- ENA fastq for quality-less runs carries **synthetic** qualities → quality-trim is a no-op for those (curation call).
- Adds EBI/ENA as a runtime dependency; per-run SRA fallback covers outages.

Adds ADR-0012 + CHANGELOG `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)