### PR TITLE
feat(resistome): replace RGI/CARD with KMA/CARD, run on both branches (2.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ nextflow run main.nf -profile local --metadata_tsv samples.tsv
 | `rarefaction.nf` | `rarefy_fastq` (seqtk downsampling) |
 | `gtdb.nf` | `metaphlan_to_gtdb` (SGB→GTDB profile conversion) |
 | `kraken.nf` | `kraken2`, `bracken` (complementary read-based profiling) |
-| `resistome.nf` | `resistome` (RGI/CARD read-based AMR profiling, full branch only) |
+| `resistome.nf` | `resistome_kma` (KMA/CARD read-based AMR profiling, both branches) |
 | `qc.nf` | `fastqc` (post-decontamination FastQC) |
 | `manifest.nf` | `sample_manifest` (per-sample provenance + read-accounting `manifest.json`) |
 | `databases.nf` | Reference database downloads (MetaPhlAn, KneadData, HUMAnN, SGB→GTDB, Kraken2, CARD DBs) |
@@ -53,7 +53,7 @@ GTDB conversion uses the vendored `bin/sgb_to_gtdb_profile.py` (Nextflow stages 
 
 `kraken2`/`bracken` (module `kraken.nf`, gated by `skip_kraken`) add a complementary read-based profile under each branch's `kraken/` subdirectory. They use per-process StaPH-B containers and set all directives (container, resources, `maxForks`) **in the process body** rather than `conf/base.config`, because they are imported under aliases. The Kraken2 DB is loaded into RAM (default mode, not memory-mapped or staged to scratch) for cluster portability; `kraken_maxforks` throttles concurrent reads of the DB off shared storage. See ADR-0006.
 
-`resistome` (module `resistome.nf`, gated by `skip_resistome`) runs RGI's read-based `bwt` workflow against CARD, publishing AMR gene/allele mapping tables under a `resistome/` subdirectory. It runs on the **full branch only** (ARGs are sparse at the rarefied depth) but keeps the branch-aware publishDir, so with rarefaction active it lands in `full_data/resistome/`. Container/resources are set in the process body. The RGI command sequence is not exercised by stub tests; validate it on a real sample. See ADR-0007.
+`resistome_kma` (module `resistome.nf`, gated by `skip_resistome`) maps the decontaminated reads against a **KMA-indexed CARD** reference (`kma ... -ef`), publishing `card_kma.*.gz` outputs under a `resistome/` subdirectory. CARD is downloaded and its homolog-model FASTA indexed once into `store_dir` (`card_db` → `card_kma_db` in `databases.nf`; the index step runs in the KMA biocontainer). Unlike the former RGI step it runs on **both branches** (imported under `resistome_kma_full`/`resistome_kma_rarefied` aliases), with container/resources set in the process body. The KMA command is not exercised by stub tests; validate it on a real sample. See ADR-0012 (supersedes ADR-0007).
 
 `fastqc` (module `qc.nf`, gated by `skip_fastqc`) runs FastQC on the **decontaminated** reads (`<sample>/fastqc/`); raw-read FastQC already runs in `fasterq_dump`/`local_fastqc`, so this gives a before/after view. It runs in the base image (no new container). A per-sample MultiQC report was considered but dropped to avoid introducing another container (see ADR-0008). Per-sample only.
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -56,7 +56,8 @@ process {
      * db_setup: every reference/database process in
      *   modules/processes/databases.nf (install_metaphlan_db, chocophlan_db,
      *   utility_mapping_db, uniref_db, sgb_to_gtdb_db, kraken_db, card_db,
-     *   kneaddata_human_database, kneaddata_mouse_database). These are shared
+     *   card_kma_db, kneaddata_human_database, kneaddata_mouse_database). These
+     *   are shared
      *   across the whole batch via storeDir. A broken shared DB must stop the
      *   run loudly rather than silently ruin every sample, so retry transient
      *   failures (with growing memory for the OOM family) and then 'finish'.

--- a/docs/adr/0007-resistome-rgi-card.md
+++ b/docs/adr/0007-resistome-rgi-card.md
@@ -1,6 +1,6 @@
 # 0007. Resistome profiling with RGI against CARD
 
-- **Status:** Accepted (implemented)
+- **Status:** Superseded by [0012](0012-resistome-kma-card.md)
 - **Date:** 2026-06-03
 - **Deciders:** Sean Davis
 

--- a/docs/adr/0012-resistome-kma-card.md
+++ b/docs/adr/0012-resistome-kma-card.md
@@ -1,0 +1,72 @@
+# 0012. Resistome profiling with KMA against CARD
+
+- **Status:** Accepted (supersedes [0007](0007-resistome-rgi-card.md))
+- **Date:** 2026-07-04
+- **Deciders:** Sean Davis
+
+## Context
+
+[ADR-0007](0007-resistome-rgi-card.md) added read-based resistome profiling with
+RGI's `bwt` workflow against CARD. In practice RGI is heavyweight for this use:
+it requires a multi-step `load` / `card_annotation` / `load` dance to build a
+run-local database before every alignment, it is comparatively slow, and its
+cost meant we restricted it to the full-depth branch only — leaving the rarefied
+branch without a resistome for side-by-side comparison.
+
+We still want an assembly-free, per-sample AMR gene profile against CARD, but
+with a simpler, faster tool that we can afford to run on both branches.
+
+## Decision
+
+We will replace RGI with **KMA** (k-mer alignment,
+https://bitbucket.org/genomicepidemiology/kma) mapping the host-decontaminated
+reads directly against a **KMA-indexed CARD reference**.
+
+- The CARD "broadstreet" release is downloaded once into `store_dir`; its
+  homolog-model nucleotide FASTA (`nucleotide_fasta_protein_homolog_model.fasta`)
+  is indexed with `kma index` into a separate `store_dir`-backed asset
+  (`card_kma_db`) so the index is built once and reused across runs.
+- Alignment runs on **both the full and rarefied branches** (KMA is cheap
+  enough), matching MetaPhlAn and Kraken, and keeps the branch-aware publishDir
+  (`<sample>/<branch>/resistome`).
+- KMA runs in its own pinned biocontainer per [0001](0001-container-strategy.md)
+  (`quay.io/biocontainers/kma`); indexing runs in the same image (the base image
+  has no KMA).
+- KMA is invoked with `-ef` (extended features / `.mapstat`) for ARG
+  quantification; all plain-text outputs are gzipped before publishing.
+
+## Alternatives considered
+
+- **Keep RGI/CARD (ADR-0007)** — well-recognized, but the multi-step
+  load/annotate setup and cost pushed us to full-branch-only. Rejected for
+  simplicity and to enable both branches.
+- **Build a custom KMA container** — the `kma-adr.md` spec suggested building
+  one, but a maintained biocontainer already exists and matches ADR-0001's
+  per-process-biocontainer policy, so we avoid owning an image lifecycle.
+- **AMR++ / MEGARes, assembly-based AMRFinderPlus** — the same trade-offs noted
+  in ADR-0007 still apply; out of scope for this read-based pass.
+
+## Consequences
+
+- **Output contract changes.** The `resistome/` directory now contains KMA
+  outputs (`card_kma.res.gz`, `card_kma.mapstat.gz`, `card_kma.aln.gz`,
+  `card_kma.fsa.gz`, `card_kma.frag.gz`) instead of the RGI
+  `rgi_bwt.*_mapping_data.txt.gz` tables. The pipeline version is bumped to
+  2.1.0 accordingly.
+- A resistome is now produced for the rarefied branch as well; ARGs are sparse
+  at 1M reads, so treat the rarefied resistome as low-sensitivity.
+- `rgi_aligner` is removed; `card_db_url` now points at the broadstreet tarball.
+- A second `store_dir` asset (`card_kma_db`, the KMA index) is introduced
+  alongside the extracted CARD data.
+- **Caveat:** the KMA index/align commands are not exercised by stub tests
+  (which do not run containers); the first real run is the true validation, as
+  with the Kraken and (former) RGI steps.
+
+## References
+
+- KMA: https://bitbucket.org/genomicepidemiology/kma/src/master/
+- CARD: https://card.mcmaster.ca/
+- Supersedes [0007](0007-resistome-rgi-card.md).
+- Implemented in: `modules/processes/resistome.nf` (`resistome_kma`),
+  `modules/processes/databases.nf` (`card_db`, `card_kma_db`), `main.nf` wiring,
+  `nextflow.config` parameters.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,8 +54,9 @@ other. This preserves the historical record rather than rewriting it.
 | [0004](0004-gtdb-conversion-vendored-mapping.md) | GTDB conversion via a vendored, store_dir-backed mapping table | Accepted |
 | [0005](0005-per-sample-manifest.md) | Per-sample provenance & read-accounting manifest | Accepted |
 | [0006](0006-kraken2-bracken-complementary-profiler.md) | Complementary read-based profiling with Kraken2 + Bracken | Accepted |
-| [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Accepted |
+| [0007](0007-resistome-rgi-card.md) | Resistome profiling with RGI against CARD | Superseded by [0012](0012-resistome-kma-card.md) |
 | [0008](0008-per-sample-qc-reporting.md) | Per-sample post-decontamination FastQC | Accepted |
 | [0009](0009-retry-and-failure-handling-policy.md) | Retry and failure-handling policy | Accepted (error-action superseded by 0010) |
 | [0010](0010-error-strategy-finish.md) | Use errorStrategy 'finish' instead of 'terminate' | Accepted |
 | [0011](0011-gcs-storage-profile-split.md) | Split the GCS storage profile (publish vs work) | Accepted |
+| [0012](0012-resistome-kma-card.md) | Resistome profiling with KMA against CARD | Accepted |

--- a/main.nf
+++ b/main.nf
@@ -26,6 +26,7 @@ include {
     sgb_to_gtdb_db
     kraken_db
     card_db
+    card_kma_db
 } from './modules/processes/databases'
 include {
     kneaddata
@@ -48,7 +49,10 @@ include {
     bracken as bracken_full
     bracken as bracken_rarefied
 } from './modules/processes/kraken'
-include { resistome } from './modules/processes/resistome'
+include {
+    resistome_kma as resistome_kma_full
+    resistome_kma as resistome_kma_rarefied
+} from './modules/processes/resistome'
 include { fastqc } from './modules/processes/qc'
 include { humann } from './modules/processes/humann'
 include { sample_manifest } from './modules/processes/manifest'
@@ -136,6 +140,7 @@ workflow {
     }
     if (!params.skip_resistome) {
         card_db()
+        card_kma_db(card_db.out.card_db)
     }
 
     /*
@@ -226,14 +231,15 @@ workflow {
     }
 
     /*
-     * Resistome profiling (RGI/CARD) on the full-depth host-decontaminated
-     * reads. Full branch only — ARGs are too sparse at the rarefied depth.
+     * Resistome profiling (KMA against CARD) on the full-depth
+     * host-decontaminated reads. KMA is cheap enough to run on both branches
+     * (see the rarefied section below). See ADR-0012.
      */
     if (!params.skip_resistome) {
-        resistome(
+        resistome_kma_full(
             full_meta_ch,
             kneaddata.out.fastq,
-            card_db.out.card_db.collect())
+            card_kma_db.out.card_kma_db.collect())
     }
 
     /*
@@ -323,6 +329,13 @@ workflow {
                 kraken2_rarefied.out.report,
                 kraken_db.out.kraken_db.collect())
         }
+
+        if (!params.skip_resistome) {
+            resistome_kma_rarefied(
+                rarefy_fastq.out.meta,
+                rarefy_fastq.out.fastq,
+                card_kma_db.out.card_kma_db.collect())
+        }
     }
 
     /*
@@ -374,7 +387,7 @@ workflow {
         // Gate completion on the full-branch resistome profiling.
         finished_ch = finished_ch
             .map { meta -> tuple(meta.sample, meta) }
-            .join(resistome.out.meta.map { meta -> tuple(meta.sample, meta) })
+            .join(resistome_kma_full.out.meta.map { meta -> tuple(meta.sample, meta) })
             .map { sample_id, meta1, meta2 -> meta1 }
     }
 

--- a/modules/processes/databases.nf
+++ b/modules/processes/databases.nf
@@ -226,7 +226,7 @@ process card_db {
     stub:
     """
     mkdir -p card_db
-    touch card_db/card.json
+    touch card_db/nucleotide_fasta_protein_homolog_model.fasta
     touch .command.run
     """
 
@@ -234,11 +234,58 @@ process card_db {
     """
     echo ${PWD}
     mkdir -p card_db
-    # The canonical CARD data is a bzip2 tarball containing card.json and the
-    # ontology index files; extract it all into card_db/.
+    # The CARD "broadstreet" release is a bzip2 tarball; we index the homolog-
+    # model nucleotide FASTA with KMA (see card_kma_db). Extract with Python's
+    # tarfile so we do not depend on a bzip2 binary being present in the image.
     curl -fsSL "${params.card_db_url}" -o card_data.tar.bz2
-    tar -xjf card_data.tar.bz2 -C card_db
+    python -c "import tarfile; tarfile.open('card_data.tar.bz2','r:bz2').extractall('card_db')"
     rm -f card_data.tar.bz2
+    """
+}
+
+process card_kma_db {
+    label 'db_setup'
+
+    // KMA is not in the base image; index CARD in its own pinned biocontainer
+    // (ADR-0001). This is a shared, storeDir-backed asset reused across runs.
+    container 'docker://quay.io/biocontainers/kma:1.6.13--h118bc1c_0'
+
+    cpus 2
+    memory "8g"
+
+    storeDir "${params.store_dir}"
+
+    input:
+    path card_db
+
+    output:
+    path "card_kma_db", emit: card_kma_db, type: 'dir'
+    path ".command*"
+    path "versions.yml"
+
+    stub:
+    """
+    mkdir -p card_kma_db
+    touch card_kma_db/card_kma_db.comp.b
+    touch card_kma_db/card_kma_db.length.b
+    touch card_kma_db/card_kma_db.name
+    touch card_kma_db/card_kma_db.seq.b
+    touch .command.run
+    touch versions.yml
+    """
+
+    script:
+    """
+    echo ${PWD}
+    mkdir -p card_kma_db
+    kma index \
+        -i ${card_db}/nucleotide_fasta_protein_homolog_model.fasta \
+        -o card_kma_db/card_kma_db
+
+    cat <<-END_VERSIONS > versions.yml
+    versions:
+        kma: \$( kma -v 2>&1 | head -n1 | sed 's/^KMA-//' )
+    END_VERSIONS
     """
 }
 

--- a/modules/processes/resistome.nf
+++ b/modules/processes/resistome.nf
@@ -1,26 +1,28 @@
 /*
- * Resistome profiling: RGI against CARD (ADR-0007)
+ * Resistome profiling: KMA against CARD (ADR-0012, supersedes ADR-0007)
  *
- * RGI's read-based `bwt` workflow aligns the host-decontaminated reads against
- * the CARD reference and reports antimicrobial-resistance gene and allele
- * abundances, assembly-free. Runs on the full-depth branch only (ARGs are rare;
- * the rarefied depth yields a sparse, low-value resistome).
+ * KMA (k-mer alignment) maps the host-decontaminated reads directly against a
+ * KMA-indexed CARD reference (the homolog-model nucleotide FASTA; see
+ * card_kma_db in databases.nf) and reports antimicrobial-resistance gene
+ * template hits with depth/coverage statistics, assembly-free.
  *
- * Container and resources are set in the process body (not conf/base.config) to
- * stay consistent with the other tool-specific processes that override the base
- * image (e.g. kraken2/bracken).
+ * Unlike the previous RGI/CARD resistome (full-branch only), KMA is cheap
+ * enough to run on BOTH the full and rarefied branches, matching MetaPhlAn and
+ * Kraken. It is imported under per-branch aliases, so container and resource
+ * directives live in the process body (not conf/base.config) to apply
+ * regardless of alias.
  *
- * NOTE: The RGI load + bwt invocation follows the CARD documentation but is not
- * exercised by the stub tests (which do not run containers); the first real run
- * is the true validation. See docs/adr/0007-resistome-rgi-card.md.
+ * NOTE: The KMA invocation is not exercised by stub tests (which do not run
+ * containers); the first real run is the true validation. See
+ * docs/adr/0012-resistome-kma-card.md.
  */
 
-process resistome {
-    container 'docker://quay.io/biocontainers/rgi:6.0.5--pyh05cac1d_0'
+process resistome_kma {
+    container 'docker://quay.io/biocontainers/kma:1.6.13--h118bc1c_0'
 
     label 'profiling'
 
-    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/${meta.branch ? meta.branch + '/' : ''}resistome", pattern: "{*.txt.gz,.command*}", mode: "${params.publish_mode}"
+    publishDir "${params.publish_dir ?: "${params.publish_base_dir}/${workflow.manifest.name}/${workflow.manifest.version}"}/${meta.sample}/${meta.branch ? meta.branch + '/' : ''}resistome", pattern: "{*.gz,.command*}", mode: "${params.publish_mode}"
 
     tag "${meta.sample}"
 
@@ -34,46 +36,43 @@ process resistome {
 
     output:
     val(meta), emit: meta
-    path "rgi_bwt.gene_mapping_data.txt.gz", emit: gene_mapping
-    path "rgi_bwt.allele_mapping_data.txt.gz", emit: allele_mapping
-    path "rgi_bwt.*mapping_stats.txt.gz"
+    path "card_kma.res.gz", emit: res
+    path "card_kma.mapstat.gz", emit: mapstat
+    path "card_kma.aln.gz"
+    path "card_kma.fsa.gz"
+    path "card_kma.frag.gz"
     path ".command*"
     path "versions.yml", emit: versions
 
     stub:
     """
-    touch rgi_bwt.gene_mapping_data.txt.gz
-    touch rgi_bwt.allele_mapping_data.txt.gz
-    touch rgi_bwt.overall_mapping_stats.txt.gz
+    touch card_kma.res.gz
+    touch card_kma.mapstat.gz
+    touch card_kma.aln.gz
+    touch card_kma.fsa.gz
+    touch card_kma.frag.gz
     touch .command.run
     touch versions.yml
     """
 
     script:
     """
-    # Load CARD canonical data into a run-local database (--local writes a
-    # localDB/ in the work dir, so no writable package install is required).
-    rgi load --card_json ${card_db}/card.json --local
+    # Reads are single-end throughout the pipeline. -ef adds the extended
+    # mapstat table (fragment counts, depth) that is useful for ARG
+    # quantification. KMA writes card_kma.frag.gz already gzipped.
+    kma \
+        -i ${reads} \
+        -o card_kma \
+        -t_db ${card_db}/card_kma_db \
+        -t ${task.cpus} \
+        -ef
 
-    # Build and load the bwt reference annotation; card_annotation writes a
-    # version-stamped FASTA (card_database_v<CARD version>.fasta).
-    rgi card_annotation -i ${card_db}/card.json
-    card_fasta=\$(ls card_database_v*.fasta | grep -v '_all' | head -n 1)
-    rgi load --card_json ${card_db}/card.json --card_annotation "\$card_fasta" --local
-
-    rgi bwt \
-        --read_one ${reads} \
-        --aligner ${params.rgi_aligner} \
-        --threads ${task.cpus} \
-        --output_file rgi_bwt \
-        --local \
-        --clean
-
-    gzip rgi_bwt.*.txt
+    # Compress the remaining plain-text outputs to save space.
+    gzip card_kma.res card_kma.fsa card_kma.aln card_kma.mapstat
 
     cat <<-END_VERSIONS > versions.yml
     versions:
-        rgi: \$( rgi main --version 2>&1 | tail -n 1 )
+        kma: \$( kma -v 2>&1 | head -n1 | sed 's/^KMA-//' )
     END_VERSIONS
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -94,20 +94,21 @@ params {
     bracken_read_length = 100
 
     /*
-     * Resistome profiling: RGI against CARD (ADR-0007)
+     * Resistome profiling: KMA against CARD (ADR-0012, supersedes ADR-0007)
      *
      * When skip_resistome is false (the default), the host-decontaminated reads
-     * are profiled for antimicrobial-resistance genes with RGI's read-based
-     * `bwt` workflow against the CARD database. This runs on the full-depth
-     * branch only (ARGs are rare; the rarefied 1M-read depth yields a sparse,
-     * low-value resistome), and publishes under a `resistome` subdirectory.
+     * are profiled for antimicrobial-resistance genes with KMA against a
+     * KMA-indexed CARD reference and published under a `resistome`
+     * subdirectory. Unlike the previous RGI/CARD step (full branch only), KMA
+     * is cheap enough to run on both the full and rarefied branches, matching
+     * MetaPhlAn and Kraken.
      *
-     * card_db_url is the canonical CARD data tarball; it is downloaded once into
-     * store_dir. rgi_aligner selects the bwt read aligner (bowtie2|bwa|kma).
+     * card_db_url is the CARD "broadstreet" release tarball; it is downloaded
+     * once into store_dir, and its homolog-model nucleotide FASTA is indexed
+     * with KMA (also cached in store_dir) for reuse across runs.
      */
     skip_resistome = false
-    card_db_url = 'https://card.mcmaster.ca/latest/data'
-    rgi_aligner = 'bowtie2'
+    card_db_url = 'https://card.mcmaster.ca/download/0/broadstreet-v4.0.1.tar.bz2'
 
     /*
      * Per-sample QC (ADR-0008)
@@ -190,7 +191,7 @@ manifest {
     homePage = 'https://github.com/seandavi/curatedmetagenomicsnextflow'
     mainScript = 'main.nf'
     name = 'cmgd_nextflow'
-    version = '2.0.7'
+    version = '2.1.0'
 }
 
 report {


### PR DESCRIPTION
## Summary

Replaces the read-based resistome step (RGI `bwt` against CARD) with **KMA against a KMA-indexed CARD reference**. KMA is lighter and fast enough to run on **both** the full and rarefied branches (RGI ran full-only). See **ADR-0012** (supersedes ADR-0007).

## Changes

- **`databases.nf`**: `card_db` now fetches the CARD *broadstreet* release and extracts `nucleotide_fasta_protein_homolog_model.fasta` (via Python `tarfile`, no `bzip2` binary dependency). New `card_kma_db` process runs `kma index` in the KMA biocontainer, `store_dir`-cached for reuse.
- **`resistome.nf`**: `resistome_kma` runs `kma ... -ef`, publishing `card_kma.{res,mapstat,aln,fsa,frag}.gz` under `<sample>/<branch>/resistome/`. Pinned to `quay.io/biocontainers/kma:1.6.13--h118bc1c_0` per ADR-0001.
- **`main.nf`**: imported under `_full`/`_rarefied` aliases; wired on both branches; completion gating updated.
- **`nextflow.config`**: `card_db_url` → broadstreet tarball; dropped `rgi_aligner`; version **2.0.7 → 2.1.0** (output contract changed).
- **Docs**: ADR-0012; ADR-0007 marked superseded; README index; `CLAUDE.md`; `base.config` `db_setup` enumeration.

## Output contract change

`resistome/` now contains `card_kma.*.gz` (was `rgi_bwt.*_mapping_data.txt.gz`), and a resistome is now produced for the rarefied branch too (sparse at 1M reads — treat as low-sensitivity). Version bumped accordingly.

## Validation

- Stub run: 30 processes, 0 failed; both branches publish; `card_db`/`card_kma_db` cache in `store_dir`; `MARK_COMPLETE` gates correctly.
- `skip_resistome=true`: 18 processes, 0 failed.
- ⚠️ KMA `index`/align commands are stub-validated only (no container run) — first real-sample run is the true validation, same caveat the RGI step carried.

## Follow-up (separate PR)

Nextflow 26.04's strict v2 config parser rejects the top-level `import groovy.json.JsonOutput` in `nextflow.config` (pre-existing; fails on a clean checkout). Worked around here with `NXF_SYNTAX_PARSER=v1`. Config cleanup to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)