### PR TITLE
build(config): parse under strict v2 parser + add minimal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+# Minimal CI: prove the config parses under Nextflow's current (v2) parser and
+# that the pipeline wires up end-to-end via a fast, container-free stub run.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save runner time.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install Nextflow
+        run: |
+          curl -s https://get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+          nextflow -version
+
+      # Config check runs under the DEFAULT (v2) parser to lock in the config
+      # cleanup and catch any regression that reintroduces v1-only syntax.
+      - name: Config check (all profiles, v2 parser)
+        run: |
+          for profile in local anvil alpine google unitn gcs dev rollback; do
+            echo "==> $profile"
+            nextflow config -profile "$profile" >/dev/null
+          done
+
+      # The process scripts still target the v1 script grammar, so the stub run
+      # pins NXF_SYNTAX_PARSER=v1 (see justfile). Migrating the modules to the
+      # strict v2 script parser is separate, larger follow-up work.
+      - name: Stub run (structural, no containers)
+        env:
+          NXF_DISABLE_CHECK_LATEST: 'true'
+          NXF_SYNTAX_PARSER: v1
+        run: |
+          nextflow run . \
+            -profile local \
+            -stub-run \
+            -c conf/test/disable-telemetry.config \
+            --sample_id TEST_SAMPLE \
+            --run_ids SRR000001

--- a/conf/test/disable-telemetry.config
+++ b/conf/test/disable-telemetry.config
@@ -14,5 +14,12 @@ trace.enabled = false
 process.container = null
 singularity.enabled = false
 
+// Cap requested resources so structural stub runs fit on small machines (CI
+// runners, laptops). The local executor rejects any task requesting more CPUs
+// or memory than are available; several processes ask for 8-16 CPUs and up to
+// 47 GB, which exceeds a typical 4-CPU / 16-GB CI runner. Stub tasks do no real
+// work, so capping is safe and does not change what is exercised.
+process.resourceLimits = [ cpus: 2, memory: '6 GB' ]
+
 params.publish_base_dir = 'test-results'
 params.publish_dir = null

--- a/justfile
+++ b/justfile
@@ -37,9 +37,12 @@ test-config-all:
       nextflow config -profile "$profile" >/dev/null; \
     done
 
+# The config parses under the current (v2) parser, but the process scripts
+# still target the v1 script grammar, so pin the parser for anything that
+# compiles main.nf/modules until that migration happens.
 [group('test')]
 test-stub:
-    env NXF_DISABLE_CHECK_LATEST=true nextflow run . \
+    env NXF_DISABLE_CHECK_LATEST=true NXF_SYNTAX_PARSER=v1 nextflow run . \
       -profile local \
       -stub-run \
       -c conf/test/disable-telemetry.config \
@@ -52,11 +55,11 @@ test-nf-list: test-bootstrap
 
 [group('test')]
 test-nf: test-bootstrap
-    {{nf_test}} test
+    NXF_SYNTAX_PARSER=v1 {{nf_test}} test
 
 [group('test')]
 test-nf-verbose: test-bootstrap
-    {{nf_test}} test --verbose
+    NXF_SYNTAX_PARSER=v1 {{nf_test}} test --verbose
 
 [group('test')]
 test-clean:

--- a/nextflow.config
+++ b/nextflow.config
@@ -265,51 +265,61 @@ process {
  * No-ops cleanly when params.run_name or params.api_url is unset, so
  * ad-hoc local runs are unaffected. All telemetry POSTs are best-effort
  * and never fail the run.
+ *
+ * The POST logic is inlined into each handler rather than factored into a
+ * shared helper: the strict Nextflow config parser rejects top-level `def`
+ * declarations and `import` statements, but it does accept a closure assigned
+ * to workflow.onComplete/onError with fully-qualified names used inline.
  */
-import groovy.json.JsonOutput
-
-def post_run_event = { Map body ->
-    if (!params.run_name || !params.api_url) return
-    def url = "${params.api_url}/runs/${params.run_name}/event"
-    try {
-        // ProcessBuilder takes a list of args, so curl receives the JSON
-        // payload exactly as written without any shell quoting concerns.
-        def pb = new ProcessBuilder([
-            'curl', '-sf', '-X', 'POST',
-            '--max-time', '15',
-            '-F', "event=${JsonOutput.toJson(body)}",
-            url,
-        ])
-        pb.redirectErrorStream(true)
-        def proc = pb.start()
-        proc.waitFor()
-    } catch (Throwable t) {
-        // Telemetry must NEVER fail a run.
-        System.err.println "[telemetry] post_run_event swallowed: ${t.message}"
+workflow.onComplete = {
+    if (params.run_name && params.api_url) {
+        def body = [
+            type:           'workflow_oncomplete',
+            utc_time:       new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", TimeZone.getTimeZone('UTC')),
+            success:        workflow.success,
+            exit_status:    workflow.exitStatus,
+            duration_ms:    workflow.duration?.toMillis(),
+            error_message:  workflow.errorMessage,
+        ]
+        try {
+            // ProcessBuilder takes a list of args, so curl receives the JSON
+            // payload exactly as written without any shell quoting concerns.
+            def pb = new ProcessBuilder([
+                'curl', '-sf', '-X', 'POST',
+                '--max-time', '15',
+                '-F', "event=${groovy.json.JsonOutput.toJson(body)}",
+                "${params.api_url}/runs/${params.run_name}/event",
+            ])
+            pb.redirectErrorStream(true)
+            pb.start().waitFor()
+        } catch (Throwable t) {
+            // Telemetry must NEVER fail a run.
+            System.err.println "[telemetry] onComplete post swallowed: ${t.message}"
+        }
     }
 }
 
-def utc_now = {
-    new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", TimeZone.getTimeZone('UTC'))
-}
-
-workflow.onComplete = {
-    post_run_event([
-        type:           'workflow_oncomplete',
-        utc_time:       utc_now(),
-        success:        workflow.success,
-        exit_status:    workflow.exitStatus,
-        duration_ms:    workflow.duration?.toMillis(),
-        error_message:  workflow.errorMessage,
-    ])
-}
-
 workflow.onError = {
-    post_run_event([
-        type:           'workflow_onerror',
-        utc_time:       utc_now(),
-        error_message:  workflow.errorMessage,
-    ])
+    if (params.run_name && params.api_url) {
+        def body = [
+            type:           'workflow_onerror',
+            utc_time:       new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", TimeZone.getTimeZone('UTC')),
+            error_message:  workflow.errorMessage,
+        ]
+        try {
+            def pb = new ProcessBuilder([
+                'curl', '-sf', '-X', 'POST',
+                '--max-time', '15',
+                '-F', "event=${groovy.json.JsonOutput.toJson(body)}",
+                "${params.api_url}/runs/${params.run_name}/event",
+            ])
+            pb.redirectErrorStream(true)
+            pb.start().waitFor()
+        } catch (Throwable t) {
+            // Telemetry must NEVER fail a run.
+            System.err.println "[telemetry] onError post swallowed: ${t.message}"
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
## Summary

Two things, both prerequisites for having any CI at all:

1. **Config cleanup** — Nextflow 26.04 defaults to the strict **v2 config parser**, which rejects the top-level `import groovy.json.JsonOutput` and the `def post_run_event` / `def utc_now` helpers in `nextflow.config` (fails on a clean checkout, needed a `NXF_SYNTAX_PARSER=v1` workaround). The run-lifecycle telemetry logic is reworked to be v2-safe: the `import`/`def` helpers are removed and the POST logic is inlined into the `workflow.onComplete`/`onError` closures with a fully-qualified `groovy.json.JsonOutput` reference. **Config now parses under both v1 and v2 parsers**, with identical telemetry behavior.

2. **Minimal CI** (`.github/workflows/ci.yml`, on push/PR):
   - **Config check** across all profiles (`local`, `anvil`, `alpine`, `google`, `unitn`, `gcs`, `dev`, `rollback`) under the default **v2** parser — locks in the cleanup and catches any regression that reintroduces v1-only config syntax.
   - **Stub run** — fast, container-free structural check of the whole workflow graph.

## Known limitation (deliberately out of scope)

The **process scripts** (`main.nf` + `modules/**`) still target the **v1 *script* grammar** (process section ordering, etc.), which the strict v2 *script* parser rejects. Migrating those is a separate, larger, mechanical effort. Until then, the script-compiling paths pin `NXF_SYNTAX_PARSER=v1`:
- the CI stub-run step sets it explicitly;
- `justfile` sets it on `test-stub` / `test-nf*` so `just` recipes work on current Nextflow.

The config check intentionally runs **without** the override, so v2 config-compatibility is continuously verified.

## Validation (local, mirrors CI exactly)

- `nextflow config -profile <p>` for all 8 profiles under the default v2 parser: ✅
- Stub run under `NXF_SYNTAX_PARSER=v1`: **SUCCESS**, `MARK_COMPLETE` reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)