### PR TITLE
fix(telemetry): coerce ProcessBuilder args to String so onComplete/onError POST works

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -284,12 +284,16 @@ workflow.onComplete = {
         try {
             // ProcessBuilder takes a list of args, so curl receives the JSON
             // payload exactly as written without any shell quoting concerns.
+            // Coerce every element to String: ProcessBuilder copies the list
+            // into a String[], which throws if any element is a GString (the
+            // interpolated -F payload and URL are GStrings). This silently broke
+            // the POST before — see the arraycopy note in the commit.
             def pb = new ProcessBuilder([
                 'curl', '-sf', '-X', 'POST',
                 '--max-time', '15',
                 '-F', "event=${groovy.json.JsonOutput.toJson(body)}",
                 "${params.api_url}/runs/${params.run_name}/event",
-            ])
+            ]*.toString())
             pb.redirectErrorStream(true)
             pb.start().waitFor()
         } catch (Throwable t) {
@@ -307,12 +311,16 @@ workflow.onError = {
             error_message:  workflow.errorMessage,
         ]
         try {
+            // Coerce every element to String: ProcessBuilder copies the list
+            // into a String[], which throws if any element is a GString (the
+            // interpolated -F payload and URL are GStrings). This silently broke
+            // the POST before — see the arraycopy note in the commit.
             def pb = new ProcessBuilder([
                 'curl', '-sf', '-X', 'POST',
                 '--max-time', '15',
                 '-F', "event=${groovy.json.JsonOutput.toJson(body)}",
                 "${params.api_url}/runs/${params.run_name}/event",
-            ])
+            ]*.toString())
             pb.redirectErrorStream(true)
             pb.start().waitFor()
         } catch (Throwable t) {


### PR DESCRIPTION
## Summary

The run-lifecycle telemetry POST (`workflow.onComplete` / `onError` in `nextflow.config`) has **silently never worked**. `ProcessBuilder` copies its argument list into a `String[]`, which throws:

```
arraycopy: element type mismatch: can not cast one of the elements of
java.lang.Object[] to the type of the destination array, java.lang.String
```

...whenever a list element is a **GString** — and both the interpolated `-F event=...` payload and the URL are GStrings. The surrounding `try/catch` swallowed the exception, so the POST failed with no visible effect on every run.

## Not a regression

This is **pre-existing** — the previous `def post_run_event` helper (before the v2-parser cleanup in #72) built the same `ProcessBuilder([... GString ...])` and threw the identical error. The cleanup only made it observable. Verified by running the pre-cleanup config: it logged `[telemetry] post_run_event swallowed: arraycopy...` too.

## Fix

Coerce the argument list to `String` with `*.toString()` before handing it to `ProcessBuilder` (applied to both handlers).

## Validation

- **Pre-fix** probe (run with `--run_name`/`--api_url`): `[telemetry] onComplete post swallowed: arraycopy...`
- **Post-fix** same probe: runs clean, no swallowed exception — curl is actually invoked (fails gracefully against a dead endpoint, as designed).
- `nextflow config -profile local` still parses under the default v2 parser.
- Stub run: SUCCESS.

No behavior change to the pipeline compute path; telemetry remains best-effort and still cannot fail a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)