### PR TITLE
docs: catch up on the 2.1.0 KMA changes and backfill the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,38 @@ workflow revision the orchestrator dispatches — keep all three in lockstep.
   produced. See [ADR-0013](docs/adr/0013-remove-gtdb-conversion.md) (supersedes
   ADR-0004).
 
+## [2.1.0] - 2026-07-04
+
+### Added
+- **Resistome profiling with KMA against CARD**, replacing the RGI/CARD step.
+  KMA maps the host-decontaminated reads against a KMA-indexed CARD reference
+  (the broadstreet homolog-model FASTA, indexed once into `store_dir` by the new
+  `card_kma_db` process) and is cheap enough to run on **both the full and
+  rarefied branches** (RGI ran full-only). Outputs are now `card_kma.*.gz`
+  (`res`, `mapstat`, `aln`, `fsa`, `frag`) under `resistome/`, replacing the
+  `rgi_bwt.*_mapping_data.txt.gz` tables. `rgi_aligner` is removed and
+  `card_db_url` now points at the broadstreet tarball. Validated end-to-end
+  against real CARD data. See [ADR-0012](docs/adr/0012-resistome-kma-card.md)
+  (supersedes ADR-0007).
+- **Minimal CI** (`.github/workflows/ci.yml`): a config check across all
+  profiles under the current parser plus a container-free `-stub-run`, on every
+  push and pull request.
+
+### Changed
+- **`nextflow.config` now parses under the strict (v2) Nextflow config parser.**
+  The run-lifecycle telemetry hooks were reworked off top-level `import`/`def`
+  helpers (which the v2 parser rejects) into inlined `workflow.onComplete` /
+  `onError` closures. The pipeline scripts still target the v1 script grammar, so
+  runs pin `NXF_SYNTAX_PARSER=v1` (set in the `justfile` recipes and the CI stub
+  step) until that separate migration is done.
+
+### Fixed
+- **Telemetry `onComplete`/`onError` POSTs now actually fire.** They had silently
+  never worked: `ProcessBuilder` copies its arg list into a `String[]`, which
+  threw an arraycopy type-mismatch on the interpolated (GString) payload/URL and
+  was swallowed by the surrounding try/catch. Fixed by coercing the arg list with
+  `*.toString()`. (Pre-existing bug, unrelated to the parser rework.)
+
 ## [2.0.7] - 2026-07-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ A NextFlow pipeline for processing metagenomics data, implementing the curatedMe
 
 This pipeline processes raw sequencing data through multiple steps:
 1. FASTQ extraction with `fasterq-dump`
-2. Quality control with `KneadData`
+2. Quality control with `KneadData` (plus FastQC on the decontaminated reads, optional)
 3. Rarefaction to 1 M reads with `seqtk sample` (optional, enabled by default)
 4. Taxonomic profiling with `MetaPhlAn` — run on both the full and rarefied reads in parallel
-5. Functional profiling with `HUMAnN` (optional, uses full-depth reads)
+5. Complementary read-based taxonomic profiling with `Kraken2` + `Bracken` (optional, both branches)
+6. Antimicrobial-resistance profiling with `KMA` against `CARD` (optional, both branches)
+7. Functional profiling with `HUMAnN` (optional, uses full-depth reads)
+
+Each sample also gets a `manifest.json` (provenance + read accounting) and a
+`MARK_COMPLETE` sentinel once all enabled branches finish.
 
 ## Repository Structure
 
@@ -65,7 +70,7 @@ nextflow run main.nf --metadata_tsv samples.tsv --skip_humann --publish_base_dir
 | `skip_humann`    | Skip HUMAnN functional profiling | `true` |
 | `skip_rarefied`  | Skip the rarefied profiling branch | `false` |
 | `skip_kraken`    | Skip Kraken2 + Bracken read-based profiling | `false` |
-| `skip_resistome` | Skip RGI/CARD resistome profiling (full branch only) | `false` |
+| `skip_resistome` | Skip KMA/CARD resistome profiling (both branches) | `false` |
 | `skip_fastqc`    | Skip FastQC on the host-decontaminated reads | `false` |
 
 `skip_humann=true` is the current supported default. The `skip_humann=false`
@@ -135,25 +140,27 @@ memory-mapped or staged to node-local scratch) for cluster portability;
 `kraken_maxforks` limits how many tasks read it off shared storage at once. See
 [`docs/adr/0006-kraken2-bracken-complementary-profiler.md`](docs/adr/0006-kraken2-bracken-complementary-profiler.md).
 
-### Resistome (RGI/CARD) Parameters
+### Resistome (KMA/CARD) Parameters
 
 | Parameter        | Description                                          | Default |
 | ---------------- | ---------------------------------------------------- | ------- |
-| `skip_resistome` | Disable RGI/CARD resistome profiling                 | `false` |
-| `card_db_url`    | Canonical CARD data tarball URL                      | `https://card.mcmaster.ca/latest/data` |
-| `rgi_aligner`    | RGI `bwt` read aligner (`bowtie2`, `bwa`, or `kma`)  | `bowtie2` |
+| `skip_resistome` | Disable KMA/CARD resistome profiling                 | `false` |
+| `card_db_url`    | CARD "broadstreet" release tarball URL               | `https://card.mcmaster.ca/download/0/broadstreet-v4.0.1.tar.bz2` |
 
 When `skip_resistome=false` (the default), the host-decontaminated reads are
-profiled for antimicrobial-resistance genes with [RGI](https://github.com/arpcard/rgi)'s
-read-based `bwt` workflow against the [CARD](https://card.mcmaster.ca/) database,
-emitting per-sample gene- and allele-level mapping tables (`rgi_bwt.gene_mapping_data.txt.gz`,
-`rgi_bwt.allele_mapping_data.txt.gz`) plus mapping statistics under a `resistome/`
-subdirectory. CARD is downloaded once into `store_dir`.
+profiled for antimicrobial-resistance genes with [KMA](https://bitbucket.org/genomicepidemiology/kma)
+against a KMA-indexed [CARD](https://card.mcmaster.ca/) reference, emitting
+per-sample template hits with depth/coverage statistics (`card_kma.res.gz`,
+`card_kma.mapstat.gz`, plus `card_kma.{aln,fsa,frag}.gz`) under a `resistome/`
+subdirectory. The CARD broadstreet release is downloaded once into `store_dir`,
+and its homolog-model nucleotide FASTA is indexed with `kma index` (also cached
+in `store_dir`) for reuse across runs.
 
-This step runs on the **full-depth branch only** — ARGs are rare and the rarefied
-1M-read depth yields a sparse, low-value resistome — so with the rarefied branch
-active it publishes under `full_data/resistome/`. See
-[`docs/adr/0007-resistome-rgi-card.md`](docs/adr/0007-resistome-rgi-card.md).
+Unlike the previous RGI/CARD step (full branch only), KMA is cheap enough to run
+on **both the full and rarefied branches**, matching MetaPhlAn and Kraken. ARGs
+are sparse at the rarefied 1M-read depth, so treat the rarefied resistome as
+low-sensitivity. See
+[`docs/adr/0012-resistome-kma-card.md`](docs/adr/0012-resistome-kma-card.md).
 
 ### QC Parameters
 
@@ -211,7 +218,7 @@ Results will be organized by sample in the `publish_dir` directory.
 ```
 <publish_base_dir>/
 ├── cmgd_nextflow/
-│   ├── 2.0.0/
+│   ├── 2.2.0/
 │   │   ├── sample1/
 │   │   │   ├── manifest.json     (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE
@@ -222,13 +229,14 @@ Results will be organized by sample in the `publish_dir` directory.
 │   │   │   │   ├── metaphlan_markers/
 │   │   │   │   ├── strainphlan_markers/
 │   │   │   │   ├── kraken/       (only when --skip_kraken false)
-│   │   │   │   └── resistome/    (only when --skip_resistome false; full depth only)
+│   │   │   │   └── resistome/    (only when --skip_resistome false)
 │   │   │   └── rarefied_data/
 │   │   │       ├── rarefaction/
 │   │   │       ├── metaphlan_lists/
 │   │   │       ├── metaphlan_markers/
 │   │   │       ├── strainphlan_markers/
-│   │   │       └── kraken/       (only when --skip_kraken false)
+│   │   │       ├── kraken/       (only when --skip_kraken false)
+│   │   │       └── resistome/    (only when --skip_resistome false)
 │   │   ├── sample2/
 │   │   │   └── ...
 ```
@@ -238,7 +246,7 @@ Results will be organized by sample in the `publish_dir` directory.
 ```
 <publish_base_dir>/
 ├── cmgd_nextflow/
-│   ├── 2.0.0/
+│   ├── 2.2.0/
 │   │   ├── sample1/
 │   │   │   ├── manifest.json   (provenance + read accounting)
 │   │   │   ├── MARK_COMPLETE

--- a/docs/verify-before-full-run.md
+++ b/docs/verify-before-full-run.md
@@ -34,12 +34,12 @@ runs.
       ```sh
       singularity exec docker://staphb/bracken:2.9 bracken -v
       ```
-- [ ] **RGI** — `docker://quay.io/biocontainers/rgi:6.0.5--pyha8f3691_0`
-      (`modules/processes/resistome.nf`). The `--pyha8f3691_0` build suffix is
-      the most likely failure point; if the pull 404s, find the current build at
-      <https://quay.io/repository/biocontainers/rgi?tab=tags> and update the tag.
+- [ ] **KMA** — `docker://quay.io/biocontainers/kma:1.6.13--h118bc1c_0`
+      (`modules/processes/resistome.nf` and the `card_kma_db` index step in
+      `databases.nf`). If the pull 404s, find the current build at
+      <https://quay.io/repository/biocontainers/kma?tab=tags> and update the tag.
       ```sh
-      singularity exec docker://quay.io/biocontainers/rgi:6.0.5--pyha8f3691_0 rgi main --version
+      singularity exec docker://quay.io/biocontainers/kma:1.6.13--h118bc1c_0 kma -v
       ```
 
 ## 2. Database URLs resolve
@@ -58,10 +58,11 @@ runs.
       `database100mers.kmer_distrib` (matching `bracken_read_length = 100`). The
       PlusPF tarballs ship 50/75/100/150/200/250; if you change
       `bracken_read_length`, confirm the matching file exists.
-- [ ] **CARD data** (`nextflow.config` `card_db_url`) — should resolve and the
-      tarball should contain `card.json`.
+- [ ] **CARD data** (`nextflow.config` `card_db_url`) — the broadstreet tarball
+      should resolve and contain `nucleotide_fasta_protein_homolog_model.fasta`
+      (the FASTA that `card_kma_db` indexes with `kma index`).
       ```sh
-      curl -fsIL "https://card.mcmaster.ca/latest/data" | head -1
+      curl -fsIL "https://card.mcmaster.ca/download/0/broadstreet-v4.0.1.tar.bz2" | head -1
       ```
 
 ## 3. Tool invocations not exercised by stub
@@ -75,10 +76,11 @@ outside the stub. Validate them on **one real sample** (see §4) and confirm:
       at the full PlusPF DB).
 - [ ] **Bracken** produces `bracken.species.txt` / `bracken.genus.txt` (no
       "kmer distribution not found" error → confirms §2 read-length item).
-- [ ] **RGI bwt** completes for **single-end** input (`--read_one` only) and the
-      `card_annotation` step produces a `card_database_v*.fasta` that the glob in
-      `resistome.nf` picks up. Confirm `rgi_bwt.gene_mapping_data.txt` and
-      `rgi_bwt.allele_mapping_data.txt` are non-empty.
+- [ ] **KMA index** (`card_kma_db`) builds the CARD index (`card_kma_db.*`
+      files) from the homolog-model FASTA, and **KMA align** (`resistome_kma`)
+      completes for single-end input with `-ef`. Confirm the `resistome/`
+      outputs (`card_kma.res.gz`, `card_kma.mapstat.gz`) are non-empty. This
+      path is validated end-to-end against real CARD data; see ADR-0012.
 
 ## 4. End-to-end smoke test on one real sample
 
@@ -97,9 +99,10 @@ nextflow run . -profile <your_profile> \
       `strainphlan_markers/` populated.
 - [ ] `<sample>/full_data/kraken/` has `kraken2.report.txt.gz` and the Bracken
       tables.
-- [ ] `<sample>/full_data/resistome/` has the RGI mapping tables.
-- [ ] `<sample>/rarefied_data/...` mirrors the full branch (minus `resistome/`,
-      which is full-depth only).
+- [ ] `<sample>/full_data/resistome/` has the KMA outputs (`card_kma.res.gz`,
+      `card_kma.mapstat.gz`, …).
+- [ ] `<sample>/rarefied_data/...` mirrors the full branch (KMA resistome now
+      runs on the rarefied branch too, though ARGs are sparse at 1M reads).
 - [ ] `<sample>/MARK_COMPLETE` exists (the run gated on every enabled branch).
 
 ## If something fails


### PR DESCRIPTION
## Summary

Documentation-only follow-up: #71 (RGI → KMA resistome) merged without updating the prose, leaving several docs describing the old RGI step. This catches everything up and backfills the missing changelog entry.

## Changes

**`README.md`**
- Rewrote the resistome section: **RGI/CARD → KMA/CARD**, runs on **both branches**, `card_kma.*.gz` outputs, broadstreet `card_db_url`, dropped the `rgi_aligner` row; points at ADR-0012.
- Output trees: resistome no longer labeled "full depth only"; **added `resistome/` to the rarefied branch**; bumped the illustrative version literal `2.0.0` → `2.2.0`.
- Overview: added Kraken2+Bracken and KMA resistome steps (previously omitted) + a note on `manifest.json` / `MARK_COMPLETE`.

**`docs/verify-before-full-run.md`**
- RGI container/DB/validation checklist items → KMA (`kma` biocontainer tag, broadstreet FASTA in CARD, `card_kma_db` index + `kma align` validation, `card_kma.*` output checks).

**`CHANGELOG.md`**
- Backfilled the missing **[2.1.0]** entry (KMA resistome, v2-parser config cleanup + CI, telemetry ProcessBuilder fix) — the changelog previously jumped 2.0.7 → 2.2.0.

## No behavior change

Docs only. No `.nf`/`.config`/`.py` edits; CI (config check + stub run) validates unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)