### PR TITLE
fix(anvil): put store_dir on a persistent path, not purged scratch

### DIFF
--- a/conf/profiles/anvil.config
+++ b/conf/profiles/anvil.config
@@ -3,6 +3,10 @@
  *
  * Executor settings live here; generic retry and resource class behavior stays
  * in conf/base.config unless this site needs a targeted override.
+ *
+ * store_dir points at a persistent project path (not /scratch, which is
+ * periodically purged) so the reference databases are downloaded once and
+ * reused across runs; the singularity bind mount matches.
  */
 
 profiles {
@@ -12,6 +16,8 @@ profiles {
         process.time = '24h'
 
         workDir = '/anvil/scratch/x-seandavi/cmgd_data/work'
-        params.store_dir = '/anvil/scratch/x-seandavi/keep/store/'
+        params.store_dir = '/anvil/projects/x-cis240955/cmgd/store'
+
+        singularity.runOptions = "--bind /anvil/projects/x-cis240955/cmgd/store:/keep/store/"
     }
 }


### PR DESCRIPTION
## Problem

The `anvil` profile set `params.store_dir = '/anvil/scratch/x-seandavi/keep/store/'`. Anvil periodically purges `/anvil/scratch`, so the ~120 GB of reference databases (chocophlan, metaphlan, kraken, humann DBs, …) were re-downloaded and rebuilt on **every** run — ~16 h of wasted work each time. The profile was also missing the `singularity.runOptions` store bind that `alpine.config` has, so the store was never exposed at `/keep/store` inside the container.

## Fix

Mirror the working Alpine pattern:
- `params.store_dir` → persistent `/anvil/projects/x-cis240955/cmgd/store`
- add `singularity.runOptions = "--bind /anvil/projects/x-cis240955/cmgd/store:/keep/store/"`

`workDir` stays on `/anvil/scratch` (ephemeral per-run work is fine there).

The persistent store on Anvil is already populated (copied from Alpine, verified byte-identical: 30,174 objects / 119 GiB), so runs against this profile now skip the DB download entirely.

Until this merges, the same change is applied at dispatch time via the submit-template override in the telemetry repo; this PR moves it to its proper home in the pipeline config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)