### PR TITLE
fix(manifest): capture every step's tool versions in software_versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ workflow revision the orchestrator dispatches — keep all three in lockstep.
   the profiling contract.
 
 ### Fixed
+- **`manifest.json` `software_versions` was incomplete.** It only listed the
+  three tools whose `versions.yml` `sample_manifest` staged (fasterq-dump/awscli/
+  fastqc from read acquisition, kneaddata/trimmomatic/bowtie2, metaphlan) and
+  silently omitted every step added since: `kraken2`, `bracken`, the resistome
+  `kma`, the post-decontamination `fastqc`, and `humann` when enabled. Each
+  step's `versions.yml` is now collated per sample (via `collectFile`) into the
+  single file `build_manifest.py` globs, so `software_versions` reflects every
+  tool that actually ran. Skipped optional steps contribute nothing (their
+  version channels start empty), and the HUMAnN invocation moved ahead of the
+  manifest so its versions are captured when that branch is on.
 - **Resistome KMA failed on 100% of runs (`Error: 2 (No such file or
   directory)`).** KMA writes scratch files under `$TMPDIR`, and the SLURM submit
   templates export `TMPDIR` to a per-job directory that is a sibling of — and not

--- a/main.nf
+++ b/main.nf
@@ -197,6 +197,19 @@ workflow {
         install_metaphlan_db.out.metaphlan_db.collect())
 
     /*
+     * Per-sample tool versions for the manifest.
+     *
+     * Each profiling step emits a versions.yml; they are collated per sample so
+     * software_versions in manifest.json reflects every tool that actually ran.
+     * Optional steps start from an empty channel and populate their versions
+     * channel only when enabled, so a skipped step simply contributes nothing.
+     */
+    kraken_versions_ch = Channel.empty()
+    resistome_versions_ch = Channel.empty()
+    fastqc_versions_ch = Channel.empty()
+    humann_versions_ch = Channel.empty()
+
+    /*
      * Complementary read-based profiling (Kraken2 + Bracken) on the full-depth
      * host-decontaminated reads.
      */
@@ -210,6 +223,13 @@ workflow {
             kraken2_full.out.meta,
             kraken2_full.out.report,
             kraken_db.out.kraken_db.collect())
+
+        kraken_versions_ch = kraken2_full.out.meta
+            .merge(kraken2_full.out.versions)
+            .map { m, ver -> tuple(m.sample, ver) }
+            .mix(bracken_full.out.meta
+                .merge(bracken_full.out.versions)
+                .map { m, ver -> tuple(m.sample, ver) })
     }
 
     /*
@@ -222,6 +242,10 @@ workflow {
             full_meta_ch,
             kneaddata.out.fastq,
             card_kma_db.out.card_kma_db.collect())
+
+        resistome_versions_ch = resistome_kma_full.out.meta
+            .merge(resistome_kma_full.out.versions)
+            .map { m, ver -> tuple(m.sample, ver) }
     }
 
     /*
@@ -232,35 +256,69 @@ workflow {
         fastqc(
             kneaddata.out.meta,
             kneaddata.out.fastq)
+
+        fastqc_versions_ch = fastqc.out.meta
+            .merge(fastqc.out.versions)
+            .map { m, ver -> tuple(m.sample, ver) }
+    }
+
+    /*
+     * Optional HUMAnN branch (uses full-depth data only). Invoked here — ahead
+     * of the manifest — so its tool versions are captured in software_versions.
+     */
+    if (!params.skip_humann) {
+        humann(
+           metaphlan_unknown_viruses_lists_full.out.meta,
+           kneaddata.out.fastq,
+           metaphlan_markers_full.out.marker_rel_ab_w_read_stats,
+           chocophlan_db.out.chocophlan_db,
+           uniref_db.out.uniref_db,
+           utility_mapping_db.out.utility_mapping_db)
+
+        humann_versions_ch = humann.out.meta
+            .merge(humann.out.versions)
+            .map { m, ver -> tuple(m.sample, ver) }
     }
 
     /*
      * Per-sample manifest
      *
-     * Join (by sample) the raw reads + their versions, the host-decontaminated
-     * reads + versions, and the full-branch MetaPhlAn versions, then compile a
-     * single manifest.json per sample. Each output channel is merged from the
-     * same originating process so positions stay task-aligned before the join.
+     * Join (by sample) the raw reads, the host-decontaminated reads, and a
+     * per-sample collation of every step's versions.yml, then compile a single
+     * manifest.json per sample. Version files are keyed by sample and merged
+     * with collectFile into one versions_*.yml that build_manifest.py globs, so
+     * software_versions lists every tool that ran (kraken2, bracken, KMA,
+     * fastqc, and humann when enabled) rather than only the fixed core set.
      */
     raw_for_manifest = raw_meta_ch
         .merge(raw_fastq_ch)
-        .merge(raw_versions_ch)
-        .map { m, fq, ver -> tuple(m.sample, m, fq, ver) }
+        .map { m, fq -> tuple(m.sample, m, fq) }
 
     kneaddata_for_manifest = kneaddata.out.meta
         .merge(kneaddata.out.fastq)
-        .merge(kneaddata.out.versions)
-        .map { m, fq, ver -> tuple(m.sample, fq, ver) }
+        .map { m, fq -> tuple(m.sample, fq) }
 
-    metaphlan_versions_for_manifest = metaphlan_unknown_viruses_lists_full.out.meta
-        .merge(metaphlan_unknown_viruses_lists_full.out.versions)
+    collated_versions_ch = raw_meta_ch
+        .merge(raw_versions_ch)
         .map { m, ver -> tuple(m.sample, ver) }
+        .mix(kneaddata.out.meta
+            .merge(kneaddata.out.versions)
+            .map { m, ver -> tuple(m.sample, ver) })
+        .mix(metaphlan_unknown_viruses_lists_full.out.meta
+            .merge(metaphlan_unknown_viruses_lists_full.out.versions)
+            .map { m, ver -> tuple(m.sample, ver) })
+        .mix(kraken_versions_ch)
+        .mix(resistome_versions_ch)
+        .mix(fastqc_versions_ch)
+        .mix(humann_versions_ch)
+        .collectFile { sample, ver -> [ "${sample}.yml", ver ] }
+        .map { f -> tuple(f.baseName, f) }
 
     manifest_input = raw_for_manifest
         .join(kneaddata_for_manifest)
-        .join(metaphlan_versions_for_manifest)
-        .map { sample, meta, raw_fq, raw_ver, kd_fq, kd_ver, mp_ver ->
-            tuple(meta, raw_fq, raw_ver, kd_fq, kd_ver, mp_ver) }
+        .join(collated_versions_ch)
+        .map { sample, meta, raw_fq, kd_fq, versions ->
+            tuple(meta, raw_fq, kd_fq, versions) }
 
     sample_manifest(manifest_input)
 
@@ -311,19 +369,6 @@ workflow {
                 rarefy_fastq.out.fastq,
                 card_kma_db.out.card_kma_db.collect())
         }
-    }
-
-    /*
-     * Optional HUMAnN branch (uses full-depth data only)
-     */
-    if (!params.skip_humann) {
-        humann(
-           metaphlan_unknown_viruses_lists_full.out.meta,
-           kneaddata.out.fastq,
-           metaphlan_markers_full.out.marker_rel_ab_w_read_stats,
-           chocophlan_db.out.chocophlan_db,
-           uniref_db.out.uniref_db,
-           utility_mapping_db.out.utility_mapping_db)
     }
 
     /*

--- a/modules/processes/humann.nf
+++ b/modules/processes/humann.nf
@@ -43,7 +43,7 @@ process humann {
     path("out_pathcoverage_stratified.tsv.gz")
     path("out_pathcoverage.tsv.gz")
     path ".command*"
-    path "versions.yml"
+    path "versions.yml", emit: versions
 
     stub:
     """

--- a/modules/processes/manifest.nf
+++ b/modules/processes/manifest.nf
@@ -25,10 +25,8 @@ process sample_manifest {
     input:
     tuple val(meta),
           path(raw_fastq),
-          path(raw_versions, stageAs: 'versions_raw.yml'),
           path(kneaddata_fastq, stageAs: 'kneaddata.fastq'),
-          path(kneaddata_versions, stageAs: 'versions_kneaddata.yml'),
-          path(metaphlan_versions, stageAs: 'versions_metaphlan.yml')
+          path(collated_versions, stageAs: 'versions_collated.yml')
 
     output:
     val(meta), emit: meta


### PR DESCRIPTION
## Summary

`manifest.json` → `software_versions` was **incomplete**. It listed only the tools whose `versions.yml` `sample_manifest` explicitly staged — read acquisition (`fasterq-dump`/`awscli`/`fastqc`), `kneaddata`/`trimmomatic`/`bowtie2`, and `metaphlan` — and silently dropped every step added since:

- `kraken2`, `bracken`
- resistome `kma`
- post-decontamination `fastqc` (qc.nf)
- `humann` (when the branch is enabled)

Example from a recent 2.2.1 run — note the missing kraken2/bracken/kma despite those steps running:

```json
"software_versions": {
  "kneaddata": "v0.12.3", "trimmomatic": "0.39", "metaphlan": "4.2.2",
  "bowtie2": "2.5.4", "awscli": "...", "fastqc": "v0.12.1", "fasterq-dump": "3.2.1"
}
```

## Root cause

`build_manifest.py` builds `software_versions` by globbing `versions_*.yml` — it already merges *any* number of version files. The gap was purely in the **wiring**: `main.nf` only fed the manifest three of them; the newer processes emit `versions.yml` but were never joined in. HUMAnN additionally ran *after* the manifest step.

## Fix

- Each step contributes a per-sample `(sample, versions.yml)` tuple. Optional steps (`skip_kraken`/`skip_resistome`/`skip_fastqc`/`skip_humann`) start from `Channel.empty()` and populate only when enabled, so a skipped step contributes nothing without breaking the join.
- All tuples are collated per sample with `collectFile` into one `versions_collated.yml` that the builder globs — so `software_versions` now reflects every tool that actually ran.
- The **HUMAnN invocation moved ahead of the manifest** so its versions are captured when that branch is on (`humann`'s `versions.yml` gains an `emit:` label).
- `sample_manifest`'s input drops from three separate version files to the single collated one. No change to `build_manifest.py`.

## Testing

- `just test-config-local` — resolves.
- `just test-stub` — passes; `sample_manifest` + `MARK_COMPLETE` run once per sample.
- `just test-nf` — **7/7**, including the *Kraken disabled* / *resistome disabled* / *FastQC disabled* cases, which confirm the empty-channel mixing degrades correctly.
- Verified `merge_versions()` parses a concatenated multi-`versions:` block file and yields all tools (kneaddata, trimmomatic, metaphlan, bowtie2, kraken2, bracken, kma, fastqc, humann).

The stub doesn't exercise `build_manifest.py` (its stub branch echoes), so the end-to-end `software_versions` content is best confirmed on a real sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)